### PR TITLE
crdt_tree:  initial code import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# XorName - Change Log
+
+## [0.0.1]
+- Initial implementation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "crdt_tree"
+version = "0.0.1"
+authors = ["MaidSafe Developers <dev@maidsafe.net>"]
+description = "Tree Conflict-free Replicated Data Type (CRDT)"
+homepage = "http://maidsafe.net"
+edition = "2018"
+license = "MIT OR BSD-3-Clause"
+readme = "README.md"
+repository = "https://github.com/maidsafe/crdt-tree"
+
+[dependencies]
+rand = { version = "~0.7.3", default-features = false }
+serde = { version = "1.0.113", default-features = false, features = ["derive"] }
+crdts = "4.2.0"
+quickcheck = "0.9"
+
+[dev-dependencies]
+quickcheck_macros = "0.9"

--- a/LICENSE-BSD
+++ b/LICENSE-BSD
@@ -1,0 +1,11 @@
+Copyright 2020 MaidSafe.net limited.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,7 @@
+Copyright 2020 Maidsafe.net limited
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+[![Build Status](https://travis-ci.org/tree_crdt/tree_crdt.svg?branch=master)](https://travis-ci.org/tree_crdt/crdt_tree) 
+[![docs.rs](https://docs.rs/crdt_tree/badge.svg)](https://docs.rs/crdt_tree)
+
+# crdt_tree
+
+A Conflict-free Replicated Data Type (CRDT) Tree written in Rust.
+
+| [MaidSafe website](http://maidsafe.net) | [SAFE Network Forum](https://safenetforum.org/) |
+|:-------:|:-------:|
+
+## About
+
+This crate aims to be an accurate implementation of the tree crdt algorithm described in the paper: 
+
+[A highly-available move operation for replicated trees and distributed filesystems](https://martin.kleppmann.com/papers/move-op.pdf) by M. Klepmann, et al.
+
+Please refer to the paper for a description of the algorithm's properties.
+
+For clarity, data structures in this implementation are named the same as in the paper (State, Tree) or close to (OpMove --> Move, LogOpMove --> LogOp). Some are not explicitly named in the paper, such as TreeId,TreeMeta, TreeNode, Clock.
+
+### Additional References
+
+- [CRDT: The Hard Parts](https://martin.kleppmann.com/2020/07/06/crdt-hard-parts-hydra.html)
+- [Youtube Video: CRDT: The Hard Parts](https://youtu.be/x7drE24geUw)
+
+## Usage
+
+See [examples/tree.rs](examples/tree.rs) or [tests/tree.rs](tests/tree.rs).
+
+In particular, the Replica struct in examples/tree.rs may be helpful.
+
+## Other Implementations
+
+There is a PHP implementation [here](https://github.com/dan-da/crdt-php).
+
+## License
+
+This SAFE Network library is dual-licensed under the Modified BSD ([LICENSE-BSD](LICENSE-BSD) https://opensource.org/licenses/BSD-3-Clause) or the MIT license ([LICENSE-MIT](LICENSE-MIT) https://opensource.org/licenses/MIT) at your option.
+
+## Contributing
+
+Want to contribute? Great :tada:
+
+There are many ways to give back to the project, whether it be writing new code, fixing bugs, or just reporting errors. All forms of contributions are encouraged!
+
+For instructions on how to contribute, see our [Guide to contributing](https://github.com/maidsafe/QA/blob/master/CONTRIBUTING.md).

--- a/codeowners
+++ b/codeowners
@@ -1,0 +1,1 @@
+* @maidsafe/backend_codeowners

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -1,0 +1,541 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+extern crate crdts;
+
+use crdt_tree::{Clock, OpMove, State, Tree, TreeId, TreeMeta};
+use crdts::Actor;
+use rand::Rng;
+use std::collections::HashMap;
+use std::env;
+
+#[derive(Debug)]
+struct Replica<ID: TreeId, TM: TreeMeta, A: Actor> {
+    id: A,                   // Actor representing this replica.  (globally unique id).
+    state: State<ID, TM, A>, // Tree state
+    time: Clock<A>,          // Lamport Clock for this replica/tree.
+
+    // These are both for tracking causally stable threshold.
+    //  (needed for truncating logs, emptying trash)
+    latest_time_by_replica: HashMap<A, Clock<A>>,
+    track_causally_stable_threshold: bool,
+}
+
+impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
+    pub fn new(id: A) -> Self {
+        Self {
+            id: id.clone(),
+            state: State::new(),
+            time: Clock::<A>::new(id, None),
+            latest_time_by_replica: HashMap::<A, Clock<A>>::new(),
+            track_causally_stable_threshold: false,
+        }
+    }
+
+    pub fn track_causally_stable_threshold(&mut self, flag: bool) {
+        self.track_causally_stable_threshold = flag;
+    }
+
+    pub fn id(&self) -> &A {
+        &self.id
+    }
+
+    pub fn apply_ops_noref(&mut self, ops: Vec<OpMove<ID, TM, A>>) {
+        for op in ops.clone() {
+            self.time = self.time.merge(op.timestamp());
+
+            // store latest timestamp for this actor.
+            // This is only needed for calculation of
+            // causally_stable_threshold.  If that is not
+            // required, it needn't execute.
+            if self.track_causally_stable_threshold {
+                let id = op.timestamp().actor_id();
+                let result = self.latest_time_by_replica.get(id);
+                match result {
+                    Some(latest) if !(op.timestamp() > latest) => {}
+                    _ => {
+                        self.latest_time_by_replica
+                            .insert(id.clone(), op.timestamp().clone());
+                    }
+                };
+            }
+
+            self.state.apply_op(op);
+        }
+    }
+
+    pub fn state(&self) -> &State<ID, TM, A> {
+        &self.state
+    }
+
+    pub fn tree(&self) -> &Tree<ID, TM> {
+        self.state.tree()
+    }
+
+    pub fn tree_mut(&mut self) -> &mut Tree<ID, TM> {
+        self.state.tree_mut()
+    }
+
+    pub fn apply_ops(&mut self, ops: &Vec<OpMove<ID, TM, A>>) {
+        self.apply_ops_noref(ops.clone())
+    }
+
+    /*
+        // applies ops from a log.  useful for log replay.
+        fn apply_log_ops(&mut self, log_ops: &Vec<LogOpMove<TM, A>>) {
+            let mut ops: Vec::<OpMove<TM, A>> = Vec::new();
+            for log_op in log_ops {
+                ops.push(OpMove::from_log_op_move(log_op));
+            }
+            self.apply_ops(&ops);
+        }
+    */
+
+    pub fn causally_stable_threshold(&self) -> Option<&Clock<A>> {
+        // The minimum of latest timestamp from each replica
+        // is the causally stable threshold.
+
+        let mut v: Vec<&Clock<A>> = self.latest_time_by_replica.values().collect();
+        v.sort_unstable_by(|a, b| a.cmp(b));
+        if v.len() > 0 {
+            Some(v[0])
+        } else {
+            None
+        }
+    }
+
+    pub fn truncate_log(&mut self) -> bool {
+        let result = self.causally_stable_threshold();
+        match result.cloned() {
+            Some(t) => self.state.truncate_log_before(&t),
+            None => false,
+        }
+    }
+
+    pub fn tick(&mut self) -> Clock<A> {
+        self.time.tick()
+    }
+}
+
+type TypeId = u64;
+type TypeMeta<'a> = &'a str;
+type TypeActor = u64;
+
+// Returns operations representing a depth-first tree,
+// with 2 children for each parent.
+fn mktree_ops(
+    ops: &mut Vec<OpMove<TypeId, TypeMeta, TypeActor>>,
+    r: &mut Replica<TypeId, TypeMeta, TypeActor>,
+    parent_id: u64,
+    depth: usize,
+    max_depth: usize,
+) {
+    if depth > max_depth {
+        return;
+    }
+
+    for i in 0..2 {
+        let name = if i == 0 { "a" } else { "b" };
+        let child_id = new_id();
+        ops.push(OpMove::new(r.tick(), parent_id, name, child_id));
+        mktree_ops(ops, r, child_id, depth + 1, max_depth);
+    }
+}
+
+fn apply_ops_to_replicas<ID, TM, A>(
+    replicas: &mut Vec<Replica<ID, TM, A>>,
+    ops: &Vec<OpMove<ID, TM, A>>,
+) where
+    ID: TreeId,
+    A: Actor + std::fmt::Debug,
+    TM: TreeMeta,
+{
+    for r in replicas.iter_mut() {
+        r.apply_ops(ops);
+    }
+}
+
+// note: in practice a UUID (at least 128 bits should be used)
+fn new_id() -> TypeId {
+    rand::random::<TypeId>()
+}
+
+// print a treenode, recursively
+fn print_treenode<ID, TM>(tree: &Tree<ID, TM>, node_id: &ID, depth: usize, with_id: bool)
+where
+    ID: TreeId + std::fmt::Debug,
+    TM: TreeMeta + std::fmt::Debug,
+{
+    let result = tree.find(&node_id);
+    let meta = match result {
+        Some(tn) => format!("{:?}", tn.metadata()),
+        None if depth == 0 => "forest".to_string(),
+        None => {
+            panic!("tree node {:?} not found", node_id);
+        }
+    };
+    println!("{:indent$}{}", "", meta, indent = depth * 2);
+
+    for c in tree.children(&node_id) {
+        print_treenode(tree, &c, depth + 1, with_id);
+    }
+}
+
+// print a tree.
+fn print_tree<ID, TM>(tree: &Tree<ID, TM>, root: &ID)
+where
+    ID: TreeId + std::fmt::Debug,
+    TM: TreeMeta + std::fmt::Debug,
+{
+    print_treenode(tree, root, 0, false);
+}
+
+fn print_replica_trees<ID, TM, A>(repl1: &Replica<ID, TM, A>, repl2: &Replica<ID, TM, A>, root: &ID)
+where
+    ID: TreeId + std::fmt::Debug,
+    A: Actor + std::fmt::Debug,
+    TM: TreeMeta + std::fmt::Debug,
+{
+    println!("\n--replica_1 --");
+    print_tree(repl1.tree(), root);
+    println!("\n--replica_2 --");
+    print_tree(repl2.tree(), root);
+    println!("");
+}
+
+// See paper for diagram.
+fn test_concurrent_moves() {
+    let mut r1: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+    let mut r2: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+
+    let ids: HashMap<&str, TypeId> = [
+        ("root", 0),
+        ("a", new_id()),
+        ("b", new_id()),
+        ("c", new_id()),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    // Setup initial tree state.
+    let ops = vec![
+        OpMove::new(r1.tick(), 0, "root", ids["root"]),
+        OpMove::new(r1.tick(), ids["root"], "a", ids["a"]),
+        OpMove::new(r1.tick(), ids["root"], "b", ids["b"]),
+        OpMove::new(r1.tick(), ids["root"], "c", ids["c"]),
+    ];
+
+    r1.apply_ops(&ops);
+    r2.apply_ops(&ops);
+
+    println!("Initial tree state on both replicas");
+    print_tree(r1.tree(), &ids["root"]);
+
+    // replica_1 moves /root/a to /root/b
+    let repl1_ops = vec![OpMove::new(r1.tick(), ids["b"], "a", ids["a"])];
+
+    // replica_2 "simultaneously" moves /root/a to /root/c
+    let repl2_ops = vec![OpMove::new(r2.tick(), ids["c"], "a", ids["a"])];
+
+    // replica_1 applies his op, then merges op from replica_2
+    r1.apply_ops(&repl1_ops);
+    println!("\nreplica_1 tree after move");
+    print_tree(r1.tree(), &ids["root"]);
+    r1.apply_ops(&repl2_ops);
+
+    // replica_2 applies his op, then merges op from replica_1
+    r2.apply_ops(&repl2_ops);
+    println!("\nreplica_2 tree after move");
+    print_tree(r2.tree(), &ids["root"]);
+    r2.apply_ops(&repl1_ops);
+
+    // expected result: state is the same on both replicas
+    // and final path is /root/c/a because last-writer-wins
+    // and replica_2's op has a later timestamp.
+    //    if r1.state.is_equal(&r2.state) {
+    if r1.state == r2.state {
+        println!("\nreplica_1 state matches replica_2 state after each merges other's change.  conflict resolved!");
+        print_replica_trees(&r1, &r2, &ids["root"]);
+    } else {
+        println!("\nwarning: replica_1 state does not match replica_2 state after merge");
+        print_replica_trees(&r1, &r2, &ids["root"]);
+        println!("-- replica_1 state --");
+        println!("{:#?}", r1.state);
+        println!("\n-- replica_2 state --");
+        println!("{:#?}", r2.state);
+    }
+}
+
+fn test_concurrent_moves_cycle() {
+    let mut r1: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+    let mut r2: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+
+    let ids: HashMap<&str, TypeId> = [
+        ("root", 0),
+        ("a", new_id()),
+        ("b", new_id()),
+        ("c", new_id()),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    // Setup initial tree state.
+    let ops = vec![
+        OpMove::new(r1.tick(), 0, "root", ids["root"]),
+        OpMove::new(r1.tick(), ids["root"], "a", ids["a"]),
+        OpMove::new(r1.tick(), ids["root"], "b", ids["b"]),
+        OpMove::new(r1.tick(), ids["a"], "c", ids["c"]),
+    ];
+
+    r1.apply_ops(&ops);
+    r2.apply_ops(&ops);
+
+    println!("Initial tree state on both replicas");
+    print_tree(r1.tree(), &ids["root"]);
+
+    // replica_1 moves /root/b to /root/a
+    let repl1_ops = vec![OpMove::new(r1.tick(), ids["a"], "b", ids["b"])];
+
+    // replica_2 "simultaneously" moves /root/a to /root/b
+    let repl2_ops = vec![OpMove::new(r2.tick(), ids["b"], "a", ids["a"])];
+
+    // replica_1 applies his op, then merges op from replica_2
+    r1.apply_ops(&repl1_ops);
+    println!("\nreplica_1 tree after move");
+    print_tree(r1.tree(), &ids["root"]);
+    r1.apply_ops(&repl2_ops);
+
+    // replica_2 applies his op, then merges op from replica_1
+    r2.apply_ops(&repl2_ops);
+    println!("\nreplica_2 tree after move");
+    print_tree(r2.tree(), &ids["root"]);
+    r2.apply_ops(&repl1_ops);
+
+    // expected result: state is the same on both replicas
+    // and final path is /root/c/a because last-writer-wins
+    // and replica_2's op has a later timestamp.
+    if r1.state == r2.state {
+        println!("\nreplica_1 state matches replica_2 state after each merges other's change.  conflict resolved!");
+        print_replica_trees(&r1, &r2, &ids["root"]);
+    } else {
+        println!("\nwarning: replica_1 state does not match replica_2 state after merge");
+        print_replica_trees(&r1, &r2, &ids["root"]);
+        println!("-- replica_1 state --");
+        println!("{:#?}", r1.state);
+        println!("\n-- replica_2 state --");
+        println!("{:#?}", r2.state);
+    }
+}
+
+fn test_walk_deep_tree() {
+    let mut r1: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+
+    let ids: HashMap<&str, TypeId> = [("root", 0)].iter().cloned().collect();
+
+    // Generate initial tree state.
+    println!("generating ops...");
+    let mut ops = vec![OpMove::new(r1.tick(), 0, "root", ids["root"])];
+    mktree_ops(&mut ops, &mut r1, ids["root"], 2, 13);
+
+    println!("applying ops...");
+    r1.apply_ops(&ops);
+
+    println!("walking tree...");
+    r1.tree().walk(&ids["root"], &|tree, node_id, depth| {
+        if false {
+            let meta = match tree.find(node_id) {
+                Some(tn) => format!("{:?}", tn.metadata()),
+                None => format!("{:?}", node_id),
+            };
+            println!("{:indent$}{}", "", meta, indent = depth);
+        }
+    });
+
+    println!("\nnodes in tree: {}", ops.len());
+}
+
+fn test_truncate_log() {
+    let mut replicas: Vec<Replica<TypeId, TypeMeta, TypeActor>> = Vec::new();
+    let num_replicas = 5;
+
+    // start some replicas.
+    for _i in 0..num_replicas {
+        let mut r: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+        r.track_causally_stable_threshold(true); // needed for truncation
+        replicas.push(r);
+    }
+
+    let root_id = new_id();
+
+    // Generate initial tree state.
+    let mut ops = vec![OpMove::new(replicas[0].tick(), 0, "root", root_id)];
+
+    println!("generating move operations...");
+
+    // generate some initial ops from all replicas.
+    for mut r in replicas.iter_mut() {
+        let finaldepth = rand::thread_rng().gen_range(3, 6);
+        mktree_ops(&mut ops, &mut r, root_id, 2, finaldepth);
+    }
+
+    // apply all ops to all replicas
+    println!(
+        "applying {} operations to all {} replicas...\n",
+        ops.len(),
+        replicas.len()
+    );
+    apply_ops_to_replicas(&mut replicas, &ops);
+
+    #[derive(Debug)]
+    struct Stat {
+        pub replica: TypeActor,
+        pub ops_before_truncate: usize,
+        pub ops_after_truncate: usize,
+    }
+
+    let mut stats: Vec<Stat> = Vec::new();
+    for r in replicas.iter_mut() {
+        println!("truncating log of replica {}...", r.id());
+        println!(
+            "causally stable threshold: {:?}\n",
+            r.causally_stable_threshold()
+        );
+        let ops_b4 = r.state().log().len();
+        r.truncate_log();
+        let ops_after = r.state().log().len();
+        stats.push(Stat {
+            replica: *r.id(),
+            ops_before_truncate: ops_b4,
+            ops_after_truncate: ops_after,
+        });
+    }
+
+    println!("-- Stats -- ");
+    println!("\n{:#?}", stats);
+}
+
+fn test_move_to_trash() {
+    let mut r1: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+    let mut r2: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+
+    r1.track_causally_stable_threshold(true);
+    r2.track_causally_stable_threshold(true);
+
+    let ids: HashMap<&str, TypeId> = [
+        ("forest", new_id()),
+        ("trash", new_id()),
+        ("root", new_id()),
+        ("home", new_id()),
+        ("bob", new_id()),
+        ("project", new_id()),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    // Generate initial tree state.
+    //
+    // - forest
+    //   - trash
+    //   - root
+    //     - home
+    //       - bob
+    //         - project
+    let mut ops = vec![
+        OpMove::new(r1.tick(), ids["forest"], "root", ids["root"]),
+        OpMove::new(r1.tick(), ids["forest"], "trash", ids["trash"]),
+        OpMove::new(r1.tick(), ids["root"], "home", ids["home"]),
+        OpMove::new(r1.tick(), ids["home"], "bob", ids["bob"]),
+        OpMove::new(r1.tick(), ids["bob"], "project", ids["project"]),
+    ];
+
+    // add some nodes under project
+    mktree_ops(&mut ops, &mut r1, ids["project"], 2, 3);
+    r1.apply_ops(&ops);
+    r2.apply_ops(&ops);
+
+    println!("Initial tree");
+    print_tree(r1.tree(), &ids["forest"]);
+
+    // move project to trash
+    let ops = vec![OpMove::new(
+        r1.tick(),
+        ids["trash"],
+        "project",
+        ids["project"],
+    )];
+    r1.apply_ops(&ops);
+    r2.apply_ops(&ops);
+
+    println!("\nAfter project moved to trash (deleted) on both replicas");
+    print_tree(r1.tree(), &ids["forest"]);
+
+    // Initially, trashed nodes must be retained because a concurrent move
+    // operation may move them back out of the trash.
+    //
+    // Once the operation that moved a node to the trash is causally
+    // stable, we know that no future operations will refer to this node,
+    // and so the trashed node and its descendants can be discarded.
+    //
+    // note:  change r1.tick() to r2.tick() for any of the above operations to
+    //        make the causally stable threshold less than the trash operation
+    //        timestamp, which will cause this test to fail, ie hit the
+    //        "trash should not be emptied" condition.
+    let result = r2.causally_stable_threshold();
+    match result {
+        Some(cst) if cst < ops[0].timestamp() => {
+            println!(
+                "\ncausally stable threshold:\n{:#?}\n\ntrash operation:\n{:#?}",
+                cst,
+                ops[0].timestamp()
+            );
+            panic!("!error: causally stable threshold is less than trash operation timestamp");
+        }
+        None => panic!("!error: causally stable threshold not found"),
+        _ => {}
+    }
+
+    // empty trash
+    r1.tree_mut().rm_subtree(&ids["trash"], false);
+    println!("\nDelete op is now causally stable, so we can empty trash:");
+    print_tree(r1.tree(), &ids["forest"]);
+}
+
+fn print_help() {
+    let buf = "
+Usage: tree <test>
+
+<test> can be any of:
+  test_concurrent_moves
+  test_concurrent_moves_cycle
+  test_truncate_log
+  test_walk_deep_tree
+  test_move_to_trash
+
+";
+    println!("{}", buf);
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let test = if args.len() > 1 { &args[1] } else { "" };
+
+    match test {
+        "test_concurrent_moves" => test_concurrent_moves(),
+        "test_concurrent_moves_cycle" => test_concurrent_moves_cycle(),
+        "test_truncate_log" => test_truncate_log(),
+        "test_walk_deep_tree" => test_walk_deep_tree(),
+        "test_move_to_trash" => test_move_to_trash(),
+
+        _ => print_help(),
+    }
+}

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,0 +1,160 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Implements Lamport Clock
+//!
+//! For usage/examples, see:
+//!   examples/tree.rs
+//!   test/tree.rs
+//!
+//! This code aims to be an accurate implementation of the
+//! tree crdt described in:
+//!
+//! "A highly-available move operation for replicated trees
+//! and distributed filesystems" [1] by Martin Klepmann, et al.
+//!
+//! [1] https://martin.kleppmann.com/papers/move-op.pdf
+//!
+//! For clarity, data structures in this implementation are named
+//! the same as in the paper (State, Tree) or close to
+//! (OpMove --> Move, LogOpMove --> LogOp).  Some are not explicitly
+//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
+
+use crdts::quickcheck::{Arbitrary, Gen};
+use serde::{Deserialize, Serialize};
+use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
+
+use crdts::Actor;
+
+/// lamport clock + actor
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Clock<A: Actor> {
+    actor_id: A,
+    counter: u64,
+}
+
+impl<A: Actor> Clock<A> {
+    /// create new Clock instance
+    ///
+    /// typically counter should be None
+    pub fn new(actor_id: A, counter: Option<u64>) -> Self {
+        Self {
+            actor_id,
+            counter: counter.unwrap_or(0),
+        }
+    }
+
+    /// returns a new Clock with same actor but counter incremented by 1.
+    pub fn inc(&self) -> Self {
+        Self::new(self.actor_id.clone(), Some(self.counter + 1))
+    }
+
+    /// increments clock counter and returns a clone
+    pub fn tick(&mut self) -> Self {
+        self.counter += 1;
+        self.clone()
+    }
+
+    /// returns actor_id reference
+    pub fn actor_id(&self) -> &A {
+        &self.actor_id
+    }
+
+    /// returns a new Clock with same actor but counter is
+    /// max(this_counter, other_counter)
+    pub fn merge(&self, other: &Self) -> Self {
+        Self::new(
+            self.actor_id.clone(),
+            Some(std::cmp::max(self.counter, other.counter)),
+        )
+    }
+}
+
+impl<A: Actor> Ord for Clock<A> {
+    /// compares this Clock with another.
+    /// if counters are unequal, returns -1 or 1 accordingly.
+    /// if counters are equal, returns -1, 0, or 1 based on actor_id.
+    ///    (this is arbitrary, but deterministic.)
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.counter.cmp(&other.counter) {
+            Ordering::Equal => self.actor_id.cmp(&other.actor_id),
+            Ordering::Greater => Ordering::Greater,
+            Ordering::Less => Ordering::Less,
+        }
+    }
+}
+
+impl<A: Actor> PartialOrd for Clock<A> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<A: Actor> PartialEq for Clock<A> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl<A: Actor> Eq for Clock<A> {}
+
+// Generate arbitrary (random) clocks.  needed by quickcheck.
+impl<A: Actor + Arbitrary> Arbitrary for Clock<A> {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        Self {
+            actor_id: A::arbitrary(g),
+            counter: u64::arbitrary(g),
+        }
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        let mut shrunk_clocks = Vec::new();
+        if self.counter > 0 {
+            shrunk_clocks.push(Self::new(self.actor_id.clone(), Some(self.counter - 1)));
+        }
+        Box::new(shrunk_clocks.into_iter())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::quickcheck;
+
+    quickcheck! {
+        fn inc_increments_only_the_counter(clock: Clock<u8>) -> bool {
+            clock.inc() == Clock::new(clock.actor_id, Some(clock.counter + 1))
+        }
+
+        fn test_total_order(a: Clock<u8>, b: Clock<u8>) -> bool {
+            let cmp_ab = a.cmp(&b);
+            let cmp_ba = b.cmp(&a);
+
+            match (cmp_ab, cmp_ba) {
+                (Ordering::Less, Ordering::Greater) => a.counter < b.counter || a.counter == b.counter && a.actor_id < b.actor_id,
+                (Ordering::Greater, Ordering::Less) => a.counter > b.counter || a.counter == b.counter && a.actor_id > b.actor_id,
+                (Ordering::Equal, Ordering::Equal) => a.actor_id == b.actor_id && a.counter == b.counter,
+                _ => false,
+            }
+        }
+
+        fn test_partial_order(a: Clock<u8>, b: Clock<u8>) -> bool {
+            let cmp_ab = a.partial_cmp(&b);
+            let cmp_ba = b.partial_cmp(&a);
+
+            match (cmp_ab, cmp_ba) {
+                (None, None) => a.actor_id != b.actor_id,
+                (Some(Ordering::Less), Some(Ordering::Greater)) => a.counter < b.counter || a.counter == b.counter && a.actor_id < b.actor_id,
+                (Some(Ordering::Greater), Some(Ordering::Less)) => a.counter > b.counter || a.counter == b.counter && a.actor_id > b.actor_id,
+                (Some(Ordering::Equal), Some(Ordering::Equal)) => a.actor_id == b.actor_id && a.counter == b.counter,
+                _ => false
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,57 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Implements Tree Conflict-Free Replicated Data Type (CRDT).
+//!
+//! For usage/examples, see:
+//!   examples/tree.rs
+//!   test/tree.rs
+//!
+//! This code aims to be an accurate implementation of the
+//! tree crdt described in:
+//!
+//! "A highly-available move operation for replicated trees
+//! and distributed filesystems" [1] by Martin Klepmann, et al.
+//!
+//! [1] https://martin.kleppmann.com/papers/move-op.pdf
+//!
+//! For clarity, data structures in this implementation are named
+//! the same as in the paper (State, Tree) or close to
+//! (OpMove --> Move, LogOpMove --> LogOp).  Some are not explicitly
+//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
+#![deny(missing_docs)]
+
+/// This module contains a Tree.
+pub mod tree;
+
+/// This module contains State.
+pub mod state;
+
+/// This module contains a Clock.
+pub mod clock;
+
+/// This module contains OpMove.
+pub mod opmove;
+
+/// This module contains LogOpMove.
+pub mod logopmove;
+
+/// This module contains TreeId.
+pub mod treeid;
+
+/// This module contains TreeMeta.
+pub mod treemeta;
+
+/// This module contains TreeNode.
+pub mod treenode;
+
+pub use self::{
+    clock::Clock, logopmove::LogOpMove, opmove::OpMove, state::State, tree::Tree, treeid::TreeId,
+    treemeta::TreeMeta, treenode::TreeNode,
+};

--- a/src/logopmove.rs
+++ b/src/logopmove.rs
@@ -1,0 +1,101 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Implements LogOpMove, a log entry used by State
+//!
+//! For usage/examples, see:
+//!   examples/tree.rs
+//!   test/tree.rs
+//!
+//! This code aims to be an accurate implementation of the
+//! tree crdt described in:
+//!
+//! "A highly-available move operation for replicated trees
+//! and distributed filesystems" [1] by Martin Klepmann, et al.
+//!
+//! [1] https://martin.kleppmann.com/papers/move-op.pdf
+//!
+//! For clarity, data structures in this implementation are named
+//! the same as in the paper (State, Tree) or close to
+//! (OpMove --> Move, LogOpMove --> LogOp).  Some are not explicitly
+//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
+
+use serde::{Deserialize, Serialize};
+use std::cmp::{Eq, PartialEq};
+
+use super::{Clock, OpMove, TreeId, TreeMeta, TreeNode};
+use crdts::Actor;
+
+/// From the paper:
+/// ----
+/// In order to correctly apply move operations, a replica needs
+/// to maintain not only the current state of the tree, but also
+/// an operation log.  The log is a list of LogMove records in
+/// descending timestamp order.  LogMove t oldp p m c is similar
+/// to Move t p m c; the difference is that LogMove has an additional
+/// field oldp of type ('n x 'm) option.  This option type means
+/// the field can either take the value None or a pair of a node ID
+/// and a metadata field.
+///
+/// When a replica applies a Move operation to its tree it
+/// also records a corresponding LogMove operation in its log.
+/// The t, p, m, and c fields are taken directly from the Move
+/// record while the oldp field is filled in based on the
+/// state of the tree before the move.  If c did not exist
+/// in the tree, oldp is set to None. Else oldp records the
+/// previous parent metadata of c: if there exist p' and m'
+/// such that (p', m', c') E tree, then oldp is set to Some(p', m').
+/// The get_parent() function implements this.
+/// ----
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogOpMove<ID: TreeId, TM: TreeMeta, A: Actor> {
+    // an operation that is being logged.
+    op: OpMove<ID, TM, A>,
+
+    /// parent and metadata prior to application of op.
+    /// None if op.child_id did not previously exist in tree.
+    oldp: Option<TreeNode<ID, TM>>,
+}
+
+impl<ID: TreeId, TM: TreeMeta, A: Actor> LogOpMove<ID, TM, A> {
+    /// create a new instance of LogOpMove
+    pub fn new(op: OpMove<ID, TM, A>, oldp: Option<TreeNode<ID, TM>>) -> LogOpMove<ID, TM, A> {
+        LogOpMove { op, oldp }
+    }
+
+    /// returns timestamp reference
+    pub fn timestamp(&self) -> &Clock<A> {
+        self.op.timestamp()
+    }
+
+    /// returns parent_id reference
+    pub fn parent_id(&self) -> &ID {
+        self.op.parent_id()
+    }
+
+    /// returns metadata reference
+    pub fn metadata(&self) -> &TM {
+        self.op.metadata()
+    }
+
+    /// returns child_id reference
+    pub fn child_id(&self) -> &ID {
+        &self.op.child_id()
+    }
+
+    /// returns oldp reference
+    pub fn oldp(&self) -> &Option<TreeNode<ID, TM>> {
+        &self.oldp
+    }
+
+    /// converts LogOpMove into an OpMove
+    pub fn op_into(self) -> OpMove<ID, TM, A> {
+        self.op
+    }
+}

--- a/src/opmove.rs
+++ b/src/opmove.rs
@@ -1,0 +1,146 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Implements OpMove, the only way to manipulate Tree data.
+//!
+//! OpMove are applied via State::apply_op()
+//!
+//! For usage/examples, see:
+//!   examples/tree.rs
+//!   test/tree.rs
+//!
+//! This code aims to be an accurate implementation of the
+//! tree crdt described in:
+//!
+//! "A highly-available move operation for replicated trees
+//! and distributed filesystems" [1] by Martin Klepmann, et al.
+//!
+//! [1] https://martin.kleppmann.com/papers/move-op.pdf
+//!
+//! For clarity, data structures in this implementation are named
+//! the same as in the paper (State, Tree) or close to
+//! (OpMove --> Move, LogOpMove --> LogOp).  Some are not explicitly
+//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
+
+use serde::{Deserialize, Serialize};
+use std::cmp::{Eq, PartialEq};
+
+use super::{Clock, LogOpMove, TreeId, TreeMeta};
+use crdts::quickcheck::{Arbitrary, Gen};
+use crdts::Actor;
+
+/// From the paper:
+/// ----
+/// We allow the tree to be updated in three ways: by creating
+/// a new child of any parent node, by deleting a node, or by
+/// moving a node to be a child of a new parent.  However all
+/// three types of update can be represented by a move operation.
+/// To create a node, we generate a fresh ID for that node, and
+/// issue an operation to move this new ID to be created.  We
+/// also designate as "trash" some node ID that does not exist
+/// in the tree; then we can delete a node by moving it to be
+/// a child of the trash.
+///
+/// Thus, we define one kind of operation: Move t p m c.  A move
+/// operation is a 4-tuple consisting of a timestamp t of type 't,
+/// a parent node ID p of type 'n, a metadata field m of type 'm,
+/// and a child node ID c of type 'n.  Here, 't, 'n, and 'm are
+/// type variables that can be replaced with arbitrary types;
+/// we only require that node identifiers 'n are globally unique
+/// (eg UUIDs); timestamps 't need to be globally unique and
+/// totally ordered (eg Lamport timestamps [11]).
+///
+/// The meaning of an operation Move t p m c is that at time t,
+/// the node with ID c is moved to be a child of the parent node
+/// with ID p.  The operation does not specify the old location
+/// of c; the algorithm simply removes c from wherever it is
+/// currently located in the tree, and moves it to p.  If c
+/// does not currently exist in the tree, it is created as a child
+/// of p.
+///
+/// The metadata field m in a move operation allows additional
+/// information to be associated with the parent-child relationship
+/// of p and c.  For example, in a filesystem, the parent and
+/// child are the inodes of a directory and a file within it
+/// respectively, and the metadata contains the filename of the
+/// child.  Thus, a file with inode c can be renamed by performing
+/// a Move t p m c, where the new parent directory p is the inode
+/// of the existing parent (unchanged), but the metadata m contains
+/// the new filename.
+///
+/// When users want to make changes to the tree on their local
+/// replica they generate new Move t p m c operations for these
+/// changes, and apply these operations using the algorithm
+/// described...
+/// ----
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpMove<ID: TreeId, TM: TreeMeta, A: Actor> {
+    /// lamport clock + actor
+    timestamp: Clock<A>,
+    /// parent identifier
+    parent_id: ID,
+    /// metadata.  can be anything.
+    metadata: TM,
+    /// child identifier
+    child_id: ID,
+}
+
+impl<ID: TreeId, TM: TreeMeta, A: Actor> OpMove<ID, TM, A> {
+    /// create a new OpMove instance
+    pub fn new(timestamp: Clock<A>, parent_id: ID, metadata: TM, child_id: ID) -> Self {
+        Self {
+            timestamp,
+            parent_id,
+            metadata,
+            child_id,
+        }
+    }
+
+    /// returns timestamp reference
+    pub fn timestamp(&self) -> &Clock<A> {
+        &self.timestamp
+    }
+
+    /// returns parent_id reference
+    pub fn parent_id(&self) -> &ID {
+        &self.parent_id
+    }
+
+    /// returns metadata reference
+    pub fn metadata(&self) -> &TM {
+        &self.metadata
+    }
+
+    /// returns child_id reference
+    pub fn child_id(&self) -> &ID {
+        &self.child_id
+    }
+}
+
+impl<ID: TreeId, A: Actor, TM: TreeMeta> From<LogOpMove<ID, TM, A>> for OpMove<ID, TM, A> {
+    /// creates OpMove from a LogOpMove
+    fn from(l: LogOpMove<ID, TM, A>) -> Self {
+        l.op_into()
+    }
+}
+
+// For testing with quicktest
+impl<ID: TreeId + Arbitrary, A: Actor + Arbitrary, TM: TreeMeta + Arbitrary> Arbitrary
+    for OpMove<ID, TM, A>
+{
+    /// generates an arbitrary (random) OpMove
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        Self::new(
+            Clock::arbitrary(g),
+            ID::arbitrary(g),
+            TM::arbitrary(g),
+            ID::arbitrary(g),
+        )
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,244 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Holds Tree CRDT state and implements the core algorithm.
+//!
+//! State is the primary object to instantiate that represents
+//! a CRDT Tree.
+//!
+//! For usage/examples, see:
+//!   examples/tree.rs
+//!   test/tree.rs
+//!
+//! This code aims to be an accurate implementation of the
+//! tree crdt described in:
+//!
+//! "A highly-available move operation for replicated trees
+//! and distributed filesystems" [1] by Martin Klepmann, et al.
+//!
+//! [1] https://martin.kleppmann.com/papers/move-op.pdf
+//!
+//! For clarity, data structures in this implementation are named
+//! the same as in the paper (State, Tree) or close to
+//! (OpMove --> Move, LogOpMove --> LogOp).  Some are not explicitly
+//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
+
+use serde::{Deserialize, Serialize};
+use std::cmp::{Eq, Ordering, PartialEq};
+
+use super::{Clock, LogOpMove, OpMove, Tree, TreeId, TreeMeta, TreeNode};
+use crdts::{Actor, CmRDT};
+
+/// State.  This is the primary interface for working with a
+/// Tree CRDT.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct State<ID: TreeId, TM: TreeMeta, A: Actor> {
+    // a list of LogMove in descending timestamp order.
+    log_op_list: Vec<LogOpMove<ID, TM, A>>,
+
+    // a tree structure, ie a set of (parent, meta, child) triples
+    // that represent the current state of the tree.
+    tree: Tree<ID, TM>,
+}
+
+impl<ID: TreeId, TM: TreeMeta, A: Actor> State<ID, TM, A> {
+    /// create a new State
+    pub fn new() -> Self {
+        Self {
+            log_op_list: Vec::<LogOpMove<ID, TM, A>>::default(),
+            tree: Tree::<ID, TM>::new(),
+        }
+    }
+
+    /// returns tree reference
+    pub fn tree(&self) -> &Tree<ID, TM> {
+        &self.tree
+    }
+
+    /// returns mutable tree reference
+    pub fn tree_mut(&mut self) -> &mut Tree<ID, TM> {
+        &mut self.tree
+    }
+
+    /// returns log reference
+    pub fn log(&self) -> &Vec<LogOpMove<ID, TM, A>> {
+        &self.log_op_list
+    }
+
+    /// add_log_entry
+    pub fn add_log_entry(&mut self, entry: LogOpMove<ID, TM, A>) {
+        // add at beginning of array
+        self.log_op_list.insert(0, entry);
+    }
+
+    /// removes log entries before a given timestamp.
+    /// not part of crdt-tree algo.
+    pub fn truncate_log_before(&mut self, timestamp: &Clock<A>) -> bool {
+        // newest entries are at start of list, so to find
+        // oldest entries we iterate from the end towards start.
+        let len = self.log_op_list.len();
+        let mut last_idx: usize = len - 1;
+        for (i, v) in self.log_op_list.iter().rev().enumerate() {
+            if v.timestamp() < timestamp {
+                last_idx = len - 1 - i;
+            } else {
+                break;
+            }
+        }
+
+        loop {
+            let idx = self.log_op_list.len() - 1;
+            if idx < last_idx {
+                break;
+            }
+            self.log_op_list.remove(idx);
+        }
+
+        last_idx + 1 < len
+    }
+
+    /// The do_op function performs the actual work of applying
+    /// a move operation.
+    ///
+    /// This function takes as argument a pair consisting of a
+    /// Move operation and the current tree and it returns a pair
+    /// consisting of a LogMove operation (which will be added to the log) and
+    /// an updated tree.
+    pub fn do_op(&mut self, op: OpMove<ID, TM, A>) -> LogOpMove<ID, TM, A> {
+        // When a replica applies a Move op to its tree, it also records
+        // a corresponding LogMove op in its log.  The t, p, m, and c
+        // fields are taken directly from the Move record, while the oldp
+        // field is filled in based on the state of the tree before the move.
+        // If c did not exist in the tree, oldp is set to None.  Otherwise
+        // oldp records the previous parent and metadata of c.
+        let oldp = self.tree.find(op.child_id()).cloned();
+
+        // ensures no cycles are introduced.  If the node c
+        // is being moved, and c is an ancestor of the new parent
+        // newp, then the tree is returned unmodified, ie the operation
+        // is ignored.
+        // Similarly, the operation is also ignored if c == newp
+        if op.child_id() == op.parent_id() || self.tree.is_ancestor(op.parent_id(), op.child_id()) {
+            return LogOpMove::new(op, oldp);
+        }
+
+        // Otherwise, the tree is updated by removing c from
+        // its existing parent, if any, and adding the new
+        // parent-child relationship (newp, m, c) to the tree.
+        self.tree.rm_child(op.child_id());
+        let tt = TreeNode::new(op.parent_id().to_owned(), op.metadata().to_owned());
+        self.tree.add_node(op.child_id().to_owned(), tt);
+        LogOpMove::new(op, oldp)
+    }
+
+    /// undo_op
+    pub fn undo_op(&mut self, log: &LogOpMove<ID, TM, A>) {
+        self.tree.rm_child(log.child_id());
+
+        if let Some(oldp) = log.oldp() {
+            let tn = TreeNode::new(oldp.parent_id().to_owned(), oldp.metadata().to_owned());
+            self.tree.add_node(log.child_id().to_owned(), tn);
+        }
+    }
+
+    /// redo_op uses do_op to perform an operation
+    /// again and recomputes the LogMove record (which
+    /// might have changed due to the effect of the new operation)
+    pub fn redo_op(&mut self, log: LogOpMove<ID, TM, A>) {
+        let op = OpMove::from(log);
+        let logop2 = self.do_op(op);
+
+        self.add_log_entry(logop2);
+    }
+
+    /// See general description of apply/undo/redo above.
+    ///
+    /// The apply_op func takes two arguments:
+    /// a Move operation to apply and the current replica
+    /// state; and it returns the new replica state.
+    /// The constrains `t::{linorder} in the type signature
+    /// indicates that timestamps `t are instance if linorder
+    /// type class, and they can therefore be compared with the
+    /// < operator during a linear (or total) order.
+    pub fn apply_op(&mut self, op1: OpMove<ID, TM, A>) {
+        if self.log_op_list.is_empty() {
+            let op2 = self.do_op(op1);
+            self.log_op_list = vec![op2];
+        } else {
+            match op1.timestamp().cmp(&self.log_op_list[0].timestamp()) {
+                Ordering::Equal => {
+                    // This case should never happen in normal operation
+                    // because it is required that all timestamps are unique.
+                    // The crdt paper does not even check for this case.
+                    //
+                    // We can throw an exception to catch it during dev/test.
+                    // #[cfg(debug_assertions)]
+                    // panic!("applying op with timestamp equal to previous op.  Every op should have a unique timestamp.");
+
+                    // Production code should just treat it as a non-op.
+                    // #[cfg(not(debug_assertions))]
+                }
+                Ordering::Less => {
+                    let logop = self.log_op_list.remove(0); // take from beginning of array
+                    self.undo_op(&logop);
+                    self.apply_op(op1);
+                    self.redo_op(logop);
+                }
+                Ordering::Greater => {
+                    let op2 = self.do_op(op1);
+                    self.add_log_entry(op2);
+                }
+            }
+        }
+    }
+
+    /// applies a list of operations and consume them. (no cloning)
+    pub fn apply_ops_into(&mut self, ops: Vec<OpMove<ID, TM, A>>) {
+        for op in ops {
+            self.apply_op(op);
+        }
+    }
+
+    /// applies a list of operations reference, cloning each op.
+    pub fn apply_ops(&mut self, ops: &[OpMove<ID, TM, A>]) {
+        self.apply_ops_into(ops.to_vec())
+    }
+}
+
+impl<ID: TreeId, A: Actor, TM: TreeMeta> Default for State<ID, TM, A> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// to make clippy happy.
+type LogOpList<ID, TM, A> = Vec<LogOpMove<ID, TM, A>>;
+
+impl<ID: TreeId, A: Actor, TM: TreeMeta> From<(Vec<LogOpMove<ID, TM, A>>, Tree<ID, TM>)>
+    for State<ID, TM, A>
+{
+    /// creates State from tuple (Vec<LogOpMove>, Tree)
+    fn from(e: (LogOpList<ID, TM, A>, Tree<ID, TM>)) -> Self {
+        Self {
+            log_op_list: e.0,
+            tree: e.1,
+        }
+    }
+}
+
+impl<ID: TreeId, TM: TreeMeta, A: Actor> CmRDT for State<ID, TM, A> {
+    type Op = OpMove<ID, TM, A>;
+
+    /// Apply an operation to a State instance.
+    fn apply(&mut self, op: Self::Op) {
+        self.apply_op(op);
+    }
+}
+
+// See <root>/test/tree.rs for tests

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,0 +1,181 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Implements Tree, a set of triples representing current tree structure.
+//!
+//! For usage/examples, see:
+//!   examples/tree.rs
+//!   test/tree.rs
+//!
+//! This code aims to be an accurate implementation of the
+//! tree crdt described in:
+//!
+//! "A highly-available move operation for replicated trees
+//! and distributed filesystems" [1] by Martin Klepmann, et al.
+//!
+//! [1] https://martin.kleppmann.com/papers/move-op.pdf
+//!
+//! For clarity, data structures in this implementation are named
+//! the same as in the paper (State, Tree) or close to
+//! (OpMove --> Move, LogOpMove --> LogOp).  Some are not explicitly
+//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
+
+use serde::{Deserialize, Serialize};
+use std::cmp::{Eq, PartialEq};
+use std::collections::HashMap;
+
+use super::{TreeId, TreeMeta, TreeNode};
+
+/// From the paper:
+/// ----
+/// We can represent the tree as a set of (parent, meta, child)
+/// triples, denoted in Isabelle/HOL as (’n × ’m × ’n) set. When
+/// we have (p, m, c) ∈ tree, that means c is a child of p in the tree,
+/// with associated metadata m. Given a tree, we can construct
+/// a new tree’ in which the child c is moved to a new parent p,
+/// with associated metadata m, as follows:
+///
+/// tree’ = {(p’, m’, c’) ∈ tree. c’ != c} ∪ {(p, m, c)}
+///
+/// That is, we remove any existing parent-child relationship
+/// for c from the set tree, and then add {(p, m, c)} to represent
+/// the new parent-child relationship.
+/// ----
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Tree<ID: TreeId, TM: TreeMeta> {
+    triples: HashMap<ID, TreeNode<ID, TM>>, // tree_nodes, indexed by child_id.
+    children: HashMap<ID, HashMap<ID, bool>>, // parent_id => [child_id => true].  optimization.
+}
+
+impl<ID: TreeId, TM: TreeMeta> Tree<ID, TM> {
+    /// create a new Tree instance
+    pub fn new() -> Self {
+        Self {
+            triples: HashMap::<ID, TreeNode<ID, TM>>::new(), // tree_nodes, indexed by child_id.
+            children: HashMap::<ID, HashMap<ID, bool>>::new(), // parent_id => [child_id => true].  optimization.
+        }
+    }
+
+    /// helper for removing a triple based on child_id
+    pub fn rm_child(&mut self, child_id: &ID) {
+        let result = self.triples.get(child_id);
+        if let Some(t) = result {
+            if let Some(map) = self.children.get_mut(t.parent_id()) {
+                map.remove(child_id);
+                // cleanup parent entry if empty.
+                if map.is_empty() {
+                    self.children.remove(t.parent_id());
+                }
+            }
+            self.triples.remove(child_id);
+        }
+    }
+
+    /// removes a subtree.  useful for emptying trash.
+    /// not used by crdt algo.
+    pub fn rm_subtree(&mut self, parent_id: &ID, include_parent: bool) {
+        for c in self.children(parent_id) {
+            self.rm_subtree(&c, false);
+            self.rm_child(&c);
+        }
+        if include_parent {
+            self.rm_child(parent_id)
+        }
+    }
+
+    /// adds a node to the tree
+    pub fn add_node(&mut self, child_id: ID, tt: TreeNode<ID, TM>) {
+        if let Some(n) = self.children.get_mut(tt.parent_id()) {
+            n.insert(child_id.to_owned(), true);
+        } else {
+            let mut h: HashMap<ID, bool> = HashMap::new();
+            h.insert(child_id.to_owned(), true);
+            self.children.insert(tt.parent_id().to_owned(), h);
+        }
+        self.triples.insert(child_id, tt);
+    }
+
+    /// returns matching node, or None.
+    pub fn find(&self, child_id: &ID) -> Option<&TreeNode<ID, TM>> {
+        self.triples.get(child_id)
+    }
+
+    /// returns children (IDs) of a given parent node.
+    /// useful for walking tree.
+    /// not used by crdt algo.
+    pub fn children(&self, parent_id: &ID) -> Vec<ID> {
+        if let Some(list) = self.children.get(parent_id) {
+            list.keys().cloned().collect()
+        } else {
+            Vec::<ID>::default()
+        }
+    }
+
+    /// walks tree and calls callback fn for each node.
+    /// not used by crdt algo.
+    fn walk_worker<F>(&self, parent_id: &ID, f: &F, depth: usize)
+    where
+        F: Fn(&Self, &ID, usize),
+    {
+        f(self, parent_id, depth);
+        let children = self.children(parent_id);
+        for c in children {
+            self.walk_worker(&c, f, depth + 1);
+        }
+    }
+
+    /// walks tree and calls callback fn for each node.
+    /// not used by crdt algo.
+    pub fn walk<F>(&self, parent_id: &ID, f: &F)
+    where
+        F: Fn(&Self, &ID, usize),
+    {
+        self.walk_worker(parent_id, f, 0)
+    }
+
+    /// parent | child
+    /// --------------
+    /// 1        2
+    /// 1        3
+    /// 3        5
+    /// 2        6
+    /// 6        8
+
+    ///                  1
+    ///               2     3
+    ///             6         5
+    ///           8
+    ///
+    /// is 2 ancestor of 8?  yes.
+    /// is 2 ancestor of 5?   no.
+
+    /// determines if ancestor_id is an ancestor of node_id in tree.
+    /// returns bool
+    pub fn is_ancestor(&self, child_id: &ID, ancestor_id: &ID) -> bool {
+        let mut target_id = child_id;
+        while let Some(n) = self.find(&target_id) {
+            if n.parent_id() == ancestor_id {
+                return true;
+            }
+            target_id = n.parent_id();
+        }
+        false
+    }
+}
+
+/// Implement IntoIterator for Tree.  This is useful for
+/// walking all Nodes in tree without knowing a starting point.
+impl<ID: TreeId, TM: TreeMeta> IntoIterator for Tree<ID, TM> {
+    type Item = (ID, TreeNode<ID, TM>);
+    type IntoIter = std::collections::hash_map::IntoIter<ID, TreeNode<ID, TM>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.triples.into_iter()
+    }
+}

--- a/src/treeid.rs
+++ b/src/treeid.rs
@@ -1,0 +1,33 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Implements TreeId, a trait for representing Tree (Node) Identifiers
+//!
+//! For usage/examples, see:
+//!   examples/tree.rs
+//!   test/tree.rs
+//!
+//! This code aims to be an accurate implementation of the
+//! tree crdt described in:
+//!
+//! "A highly-available move operation for replicated trees
+//! and distributed filesystems" [1] by Martin Klepmann, et al.
+//!
+//! [1] https://martin.kleppmann.com/papers/move-op.pdf
+//!
+//! For clarity, data structures in this implementation are named
+//! the same as in the paper (State, Tree) or close to
+//! (OpMove --> Move, LogOpMove --> LogOp).  Some are not explicitly
+//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
+
+use std::hash::Hash;
+
+/// TreeId trait. TreeId are unique identifiers for each node in a tree.
+pub trait TreeId: Eq + Clone + Hash {}
+impl<ID: Eq + Clone + Hash> TreeId for ID {}

--- a/src/treemeta.rs
+++ b/src/treemeta.rs
@@ -1,0 +1,32 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Implements TreeMeta, a trait for representing Tree (Node) metadata
+//!
+//! For usage/examples, see:
+//!   examples/tree.rs
+//!   test/tree.rs
+//!
+//! This code aims to be an accurate implementation of the
+//! tree crdt described in:
+//!
+//! "A highly-available move operation for replicated trees
+//! and distributed filesystems" [1] by Martin Klepmann, et al.
+//!
+//! [1] https://martin.kleppmann.com/papers/move-op.pdf
+//!
+//! For clarity, data structures in this implementation are named
+//! the same as in the paper (State, Tree) or close to
+//! (OpMove --> Move, LogOpMove --> LogOp).  Some are not explicitly
+//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
+
+/// TreeMeta trait. TreeMeta are application-defined pieces of data that are stored
+/// with each node in the Tree.
+pub trait TreeMeta: Clone {}
+impl<TM: Clone> TreeMeta for TM {}

--- a/src/treenode.rs
+++ b/src/treenode.rs
@@ -1,0 +1,67 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Implements TreeNode, ie a node that is stored in a Tree.
+//!
+//! For usage/examples, see:
+//!   examples/tree.rs
+//!   test/tree.rs
+//!
+//! This code aims to be an accurate implementation of the
+//! tree crdt described in:
+//!
+//! "A highly-available move operation for replicated trees
+//! and distributed filesystems" [1] by Martin Klepmann, et al.
+//!
+//! [1] https://martin.kleppmann.com/papers/move-op.pdf
+//!
+//! For clarity, data structures in this implementation are named
+//! the same as in the paper (State, Tree) or close to
+//! (OpMove --> Move, LogOpMove --> LogOp).  Some are not explicitly
+//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
+
+use serde::{Deserialize, Serialize};
+use std::cmp::{Eq, PartialEq};
+
+use super::{TreeId, TreeMeta};
+
+/// Represents a Node in a Tree.
+///
+/// Logically, each Node consists of a triple (parent_id, metadata, child_id).
+/// However, in this implementation, the child_id is stored as the
+/// key in Tree::triples HashMap<ID, TreeNode>
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreeNode<ID: TreeId, TM: TreeMeta> {
+    parent_id: ID,
+    metadata: TM,
+}
+
+impl<ID: TreeId, TM: TreeMeta> TreeNode<ID, TM> {
+    // parent_id: ID,
+    // metadata: TM,
+    // note: child_id is stored only as a map key in tree.
+
+    /// creates a new TreeNode instance
+    pub fn new(parent_id: ID, metadata: TM) -> Self {
+        Self {
+            parent_id,
+            metadata,
+        }
+    }
+
+    /// returns parent_id reference
+    pub fn parent_id(&self) -> &ID {
+        &self.parent_id
+    }
+
+    /// returns metadata reference
+    pub fn metadata(&self) -> &TM {
+        &self.metadata
+    }
+}

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1,0 +1,283 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+/// tests for crdt-tree
+use crdt_tree::{Clock, OpMove, State};
+use quickcheck::{Arbitrary, Gen, TestResult};
+use rand::Rng;
+use std::collections::HashMap;
+
+// Define some "real" types for use in the tests.
+type TypeId = u8;
+type TypeActor = u8;
+type TypeMeta = char;
+
+// A list of quasi-random operations for use by quickcheck.
+#[derive(Debug, Clone)]
+struct OperationList {
+    pub ops: Vec<OpMove<TypeId, TypeMeta, TypeActor>>,
+}
+
+impl Iterator for OperationList {
+    type Item = OpMove<TypeId, TypeMeta, TypeActor>;
+    fn next(&mut self) -> Option<OpMove<TypeId, TypeMeta, TypeActor>> {
+        self.ops.iter().next().cloned()
+    }
+}
+
+// generates a list of quasi-random operations.
+// For each op:
+//  1. child_id is generated randomly or picked randomly
+//      from existing ids if at least 5 existing.  (50/50 chance)
+//  2. metadata is generated randomly
+//  3. parent id is picked randomly from existing ids.
+//
+// (3) ensures that the tree is connected.
+// (1) gives us both ops that create tree nodes and ops
+//      that move existing tree nodes.
+//
+// Note that when two OperationList are merged, the
+// resulting trees will probably be disconnected.
+//
+// Note also that two OperationList may use the same
+// clock/timestamp but have different parent/child/meta
+// data.  This is an error condition for Tree, so
+// the test cases must detect and discard if this occurs.
+impl Arbitrary for OperationList {
+    fn arbitrary<G: Gen>(g: &mut G) -> OperationList {
+        let size = {
+            let s = g.size();
+            if s == 0 {
+                0
+            } else {
+                g.gen_range(0, s)
+            }
+        };
+
+        let mut clock = Clock::arbitrary(g);
+        let mut nodes: Vec<TypeId> = Vec::new();
+        let mut parent_id = TypeId::arbitrary(g);
+
+        let mut ops: Vec<OpMove<TypeId, TypeMeta, TypeActor>> = Vec::new();
+        for _ in 0..size {
+            let next_id = if nodes.len() > 5 && rand::random::<usize>() % 2 == 0 {
+                nodes[rand::random::<usize>() % nodes.len()]
+            } else {
+                TypeId::arbitrary(g)
+            };
+            nodes.push(next_id.clone());
+            let meta = TypeMeta::arbitrary(g);
+
+            let op = OpMove::new(clock.tick(), parent_id, meta, next_id);
+            let idx: usize = rand::random::<usize>() % nodes.len();
+            parent_id = nodes[idx];
+
+            ops.push(op);
+        }
+        Self { ops }
+    }
+}
+
+/// helper: checks if ops are stored in descending order in log.
+fn check_log_is_descending(s: &State<TypeId, TypeMeta, TypeActor>) -> bool {
+    let mut i = 0;
+    let log = s.log();
+    while i < log.len() - 1 {
+        let first = &log[i];
+        let second = &log[i + 1];
+
+        if !(first.timestamp() > second.timestamp()) {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+// helper: checks if tree is acyclic (good) or contains cycles (bad)
+fn acyclic(s: &State<TypeId, TypeMeta, TypeActor>) -> bool {
+    let tree = s.tree();
+
+    // Iterate all tree nodes and check if any node is an ancestor of itself.
+    for (child_id, _) in tree.clone().into_iter() {
+        if tree.is_ancestor(&child_id, &child_id) {
+            return false;
+        }
+    }
+    true
+}
+
+// helper: checks if any node has more than one parent.
+fn parent_unique(s: &State<TypeId, TypeMeta, TypeActor>) -> bool {
+    // A map of (child_id,parent_id) --> count
+    let mut cnts: HashMap<(TypeId, TypeId), usize> = HashMap::new();
+
+    // Iterate all tree nodes and store count of each child_id, parent_id pair.
+    // If any pair is found to exist more than once, the invariant is broken.
+    for (child_id, tn) in s.tree().clone().into_iter() {
+        let key = (child_id.clone(), tn.parent_id().clone());
+        let cnt = cnts.get(&key).unwrap_or(&0) + 1;
+        cnts.insert(key, cnt);
+
+        if cnt > 1 {
+            return false;
+        }
+    }
+    true
+}
+
+// helper: creates State and applies initial ops.
+fn state_from_ops(oplist: &OperationList) -> State<TypeId, TypeMeta, TypeActor> {
+    let mut s: State<TypeId, TypeMeta, TypeActor> = State::new();
+    for op in oplist.ops.iter().cloned() {
+        s.apply_op(op);
+    }
+    s
+}
+
+// helper: checks if operation lists overlap, ie use the same actor_id.
+fn ops_overlap(o1: &OperationList, o2: &OperationList) -> bool {
+    o1.ops.len() > 0
+        && o2.ops.len() > 0
+        && o1.ops[0].timestamp().actor_id() == o2.ops[0].timestamp().actor_id()
+}
+
+quickcheck::quickcheck! {
+
+    // tests that operations are idempotent
+    fn prop_idempotent(o: OperationList) -> TestResult {
+        let r1 = state_from_ops(&o);
+        let r2 = state_from_ops(&o);
+
+        // r ^ r = r
+        TestResult::from_bool(r1 == r2)
+    }
+
+    // tests that operations are commutative
+    fn prop_commutative(o1: OperationList, o2: OperationList) -> TestResult {
+
+        // discard if o1 actor is same as o2 actor
+        if ops_overlap(&o1, &o2) {
+            return TestResult::discard();
+        }
+
+        let mut r1 = state_from_ops(&o1);
+        r1.apply_ops(&o2.ops);
+
+        let mut r2 = state_from_ops(&o2);
+        r2.apply_ops(&o1.ops);
+
+        TestResult::from_bool(r1 == r2)
+    }
+
+    // tests that operations are associative
+    fn prop_associative(
+        o1: OperationList,
+        o2: OperationList,
+        o3: OperationList
+    ) -> TestResult {
+
+        // discard if: o1 actor is same as o2 actor - or -
+        //             o1 actor is same as o3 actor - or -
+        //             02 actor is same as 03 actor.
+        if ops_overlap(&o1, &o2) || ops_overlap(&o1, &o3) || ops_overlap(&o2, &o3) {
+            return TestResult::discard();
+        }
+
+        let mut r1 = state_from_ops(&o1);
+        let mut r2 = state_from_ops(&o2);
+
+        // r1 <- r2
+        r1.apply_ops(&o2.ops);
+
+        // (r1 <- r2) <- r3
+        r1.apply_ops(&o3.ops);
+
+        // r2 <- r3
+        r2.apply_ops(&o3.ops);
+
+        // (r2 <- r3) <- r1
+        r2.apply_ops(&o1.ops);
+
+        TestResult::from_bool(r1 == r2)
+    }
+
+    // tests that the tree is always acyclic
+    //
+    // From the paper:
+    // ----
+    // A graph contains no cycles if no node is an ancestor of itself.
+    // ----
+    fn prop_acyclic(o1: OperationList, o2: OperationList) -> TestResult {
+
+        // discard if o1 actor is same as o2 actor
+        if ops_overlap(&o1, &o2) {
+            return TestResult::discard();
+        }
+
+        let mut r1 = state_from_ops(&o1);
+        r1.apply_ops(&o2.ops);
+
+        let mut r2 = state_from_ops(&o2);
+        r2.apply_ops(&o1.ops);
+
+        let truth = acyclic(&r1) && acyclic(&r2);
+
+        TestResult::from_bool(truth)
+    }
+
+    // tests that each child node has exactly one parent.
+    //
+    // From the paper:
+    // ----
+    // Each tree node must have either no parent (if the root of a tree)
+    // or exactly one parent (if a non-root node).
+    // Whenever the tree contains a triple whose third element is
+    // the child node c, then the first and second elements of the
+    // triple (the parent node and the metadata) are uniquely defined.
+    // ----
+    fn prop_parent_unique(o1: OperationList, o2: OperationList) -> TestResult {
+
+        // discard if o1 actor is same as o2 actor
+        if ops_overlap(&o1, &o2) {
+            return TestResult::discard();
+        }
+
+        let mut r1 = state_from_ops(&o1);
+        r1.apply_ops(&o2.ops);
+
+        let mut r2 = state_from_ops(&o2);
+        r2.apply_ops(&o1.ops);
+
+        let truth = parent_unique(&r1) && parent_unique(&r2);
+
+        TestResult::from_bool(truth)
+    }
+
+    // tests that the operation log is always in descending order
+    // (even after applying ops from other replica)
+    fn prop_log_descending(o1: OperationList, o2: OperationList) -> TestResult {
+
+        // discard if o1 actor is same as o2 actor
+        if ops_overlap(&o1, &o2) {
+            return TestResult::discard();
+        }
+
+        let mut r1 = state_from_ops(&o1);
+        r1.apply_ops(&o2.ops);
+
+        let mut r2 = state_from_ops(&o2);
+        r2.apply_ops(&o1.ops);
+
+        let descending = check_log_is_descending(&r1) &&
+                         check_log_is_descending(&r2);
+
+        TestResult::from_bool(descending)
+    }
+}

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -1,0 +1,142 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+/// tests for crdt-tree
+use crdt_tree::{Clock, OpMove, State};
+
+// Define some "real" types for use in the tests.
+type TypeId = u8;
+type TypeActor = u8;
+type TypeMetaStr<'a> = &'a str;
+
+// helper: generate a new random id
+fn new_id() -> TypeId {
+    rand::random::<TypeId>()
+}
+
+// helper: generate a new random actor
+fn new_actor() -> TypeActor {
+    rand::random::<TypeActor>()
+}
+
+// Tests case 1 in the paper.  Concurrent moves of the same node.
+//
+// Initial State:
+// root
+//  - A
+//  - B
+//  - C
+//
+// Replica 1 moves A to be a child of B, while concurrently
+// replica 2 moves the same node A to be a child of C.
+// a child of B.  This could potentially result in A being
+// duplicated under B and C, or A having 2 parents, B and C.
+//
+// The only valid result is for one operation
+// to succeed and the other to be ignored, but both replica's
+// must pick the same success case.
+//
+// See paper for diagram.
+#[test]
+fn concurrent_moves_lww() {
+    let mut r1: State<TypeId, TypeMetaStr, TypeActor> = State::new();
+    let mut r2: State<TypeId, TypeMetaStr, TypeActor> = State::new();
+
+    let (r1_id, r2_id) = (new_actor(), new_actor());
+    let mut r1t = Clock::<TypeActor>::new(r1_id, None);
+    let mut r2t = Clock::<TypeActor>::new(r2_id, None);
+
+    let (root_id, a_id, b_id, c_id) = (new_id(), new_id(), new_id(), new_id());
+
+    // Create ops for initial tree state.
+    let ops = vec![
+        OpMove::new(r1t.tick(), 0, "root", root_id),
+        OpMove::new(r1t.tick(), root_id, "a", a_id),
+        OpMove::new(r1t.tick(), root_id, "b", b_id),
+        OpMove::new(r1t.tick(), root_id, "c", c_id),
+    ];
+
+    // Apply initial ops to both replicas
+    for op in ops {
+        r1.apply_op(op.clone());
+        r2.apply_op(op);
+    }
+
+    // replica_1 moves /root/a to /root/b
+    let r1_op = OpMove::new(r1t.tick(), b_id, "a", a_id);
+    // replica_2 "simultaneously" moves /root/a to /root/c
+    let r2_op = OpMove::new(r2t.tick(), c_id, "a", a_id);
+
+    // apply both ops to r1
+    r1.apply_op(r1_op.clone());
+    r1.apply_op(r2_op.clone());
+
+    // apply both ops to r2
+    r2.apply_op(r2_op);
+    r2.apply_op(r1_op);
+
+    assert_eq!(r1, r2);
+}
+
+// Tests case 2 in the paper.  Moving a node to be a descendant of itself.
+//
+// Initial State:
+// root
+//  - A
+//    - C
+//  - B
+//
+// Initially, nodes A and B are siblings.  Replica 1 moves B
+// to be a child of A, while concurrently replica 2 moves A to be
+// a child of B.  This could potentially result in a cyle, or
+// duplication.  The only valid result is for one operation
+// to succeed and the other to be ignored, but both replica's
+// must pick the same success case.
+//
+// See paper for diagram.
+#[test]
+fn concurrent_moves_cycle() {
+    let mut r1: State<TypeId, TypeMetaStr, TypeActor> = State::new();
+    let mut r2: State<TypeId, TypeMetaStr, TypeActor> = State::new();
+
+    let (r1_id, r2_id) = (new_actor(), new_actor());
+    let mut r1t = Clock::<TypeActor>::new(r1_id, None);
+    let mut r2t = Clock::<TypeActor>::new(r2_id, None);
+
+    let (root_id, a_id, b_id, c_id) = (new_id(), new_id(), new_id(), new_id());
+
+    // Create ops for initial tree state.
+    let ops = vec![
+        OpMove::new(r1t.tick(), 0, "root", root_id),
+        OpMove::new(r1t.tick(), root_id, "a", a_id),
+        OpMove::new(r1t.tick(), root_id, "b", b_id),
+        OpMove::new(r1t.tick(), a_id, "c", c_id),
+    ];
+
+    // Apply initial ops to both replicas
+    for op in ops {
+        r1.apply_op(op.clone());
+        r2.apply_op(op);
+    }
+
+    // replica_1 moves /root/b to /root/a
+    let r1_op = OpMove::new(r1t.tick(), a_id, "b", b_id);
+    // replica_2 "simultaneously" moves /root/a to /root/b
+    let r2_op = OpMove::new(r2t.tick(), b_id, "a", a_id);
+
+    // apply both ops to r1
+    r1.apply_op(r1_op.clone());
+    r1.apply_op(r2_op.clone());
+
+    // apply both ops to r2
+    r2.apply_op(r2_op);
+    r2.apply_op(r1_op);
+
+    assert_eq!(r1, r2);
+}


### PR DESCRIPTION
Initial import.

Has been approved by fmt and clippy.

test with `cargo test`:

```
$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.03s
     Running target/debug/deps/crdt_tree-ca2d20b71ed67dc7

running 3 tests
test clock::test::test_partial_order ... ok
test clock::test::inc_increments_only_the_counter ... ok
test clock::test::test_total_order ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/quickcheck-cd24d57bcf706296

running 6 tests
test prop_idempotent ... ok
test prop_acyclic ... ok
test prop_commutative ... ok
test prop_log_descending ... ok
test prop_parent_unique ... ok
test prop_associative ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/tree-1170724240684fcf

running 2 tests
test concurrent_moves_lww ... ok
test concurrent_moves_cycle ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests crdt_tree

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Also, run examples:

```
$ ./target/debug/examples/tree

Usage: tree <test>

<test> can be any of:
  test_concurrent_moves
  test_concurrent_moves_cycle
  test_truncate_log
  test_walk_deep_tree
  test_move_to_trash
```

eg:

```
$ ./target/debug/examples/tree test_concurrent_moves

Initial tree state on both replicas
forest
  "b"
  "a"
  "c"

replica_1 tree after move
forest
  "b"
    "a"
  "c"

replica_2 tree after move
forest
  "b"
  "c"
    "a"

replica_1 state matches replica_2 state after each merges other's change.  conflict resolved!

--replica_1 --
forest
  "b"
    "a"
  "c"

--replica_2 --
forest
  "b"
    "a"
  "c"
```