### PR TITLE
chore(inline)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rand = { version = "~0.7.3", default-features = false }
 serde = { version = "1.0.113", default-features = false, features = ["derive"] }
 crdts = "4.2.0"
 quickcheck = "0.9"
+log = "~0.4.11"
 
 [dev-dependencies]
 quickcheck_macros = "0.9"

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -11,10 +11,10 @@ extern crate crdts;
 
 use crdt_tree::{Clock, OpMove, State, Tree, TreeId, TreeMeta};
 use crdts::Actor;
+use log::debug;
 use rand::Rng;
 use std::collections::HashMap;
 use std::env;
-use log::debug;
 
 #[derive(Debug)]
 struct Replica<ID: TreeId, TM: TreeMeta, A: Actor> {
@@ -58,9 +58,9 @@ impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
             if self.track_causally_stable_threshold {
                 let id = op.timestamp().actor_id();
                 match self.latest_time_by_replica.get(id) {
-                   Some(latest) if (latest <= op.timestamp()) => {
-                                        debug!("Clock not increased, current timestamp {:?}, provided is {:?}, dropping op!", latest, op.timestamp());
-                                    }
+                    Some(latest) if (latest <= op.timestamp()) => {
+                        debug!("Clock not increased, current timestamp {:?}, provided is {:?}, dropping op!", latest, op.timestamp());
+                    }
                     _ => {
                         self.latest_time_by_replica
                             .insert(op.timestamp().actor_id().clone(), op.timestamp().clone());
@@ -108,7 +108,7 @@ impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
 
         let mut v: Vec<&Clock<A>> = self.latest_time_by_replica.values().collect();
         v.sort_unstable_by(|a, b| a.cmp(b));
-        v.pop() 
+        v.pop()
     }
 
     pub fn truncate_log(&mut self) -> bool {

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -52,21 +52,23 @@ impl<A: Actor> Clock<A> {
 
     /// returns a new Clock with same actor but counter incremented by 1.
     pub fn inc(&self) -> Self {
-        Self::new(self.actor_id.clone(), Some(self.counter + 1))
+        Self::new(self.actor_id.clone(), Some(self.counter.saturating_add(1)))
     }
 
     /// increments clock counter and returns a clone
     pub fn tick(&mut self) -> Self {
-        self.counter += 1;
+        self.counter = self.counter.saturating_add(1);
         self.clone()
     }
 
     /// returns actor_id reference
+    #[inline]
     pub fn actor_id(&self) -> &A {
         &self.actor_id
     }
 
     /// returns counter
+    #[inline]
     pub fn counter(&self) -> u64 {
         self.counter
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,6 @@ pub mod treemeta;
 pub mod treenode;
 
 pub use self::{
-clock::Clock, logopmove::LogOpMove, opmove::OpMove, state::State, tree::Tree, treeid::TreeId,
-treemeta::TreeMeta, treenode::TreeNode,
+    clock::Clock, logopmove::LogOpMove, opmove::OpMove, state::State, tree::Tree, treeid::TreeId,
+    treemeta::TreeMeta, treenode::TreeNode,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,6 @@ pub mod treemeta;
 /// This module contains `TreeNode`.
 pub mod treenode;
 
-/// Errors
-pub mod error;
-
 pub use self::{
 clock::Clock, logopmove::LogOpMove, opmove::OpMove, state::State, tree::Tree, treeid::TreeId,
 treemeta::TreeMeta, treenode::TreeNode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@ pub mod treemeta;
 /// This module contains `TreeNode`.
 pub mod treenode;
 
+/// Errors
+pub mod error;
+
 pub use self::{
 clock::Clock, logopmove::LogOpMove, opmove::OpMove, state::State, tree::Tree, treeid::TreeId,
 treemeta::TreeMeta, treenode::TreeNode,


### PR DESCRIPTION
Tag simple getters as inline to help compilers not set up for LTO etc.