### PR TITLE
Code review pr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rand = { version = "~0.7.3", default-features = false }
 serde = { version = "1.0.113", default-features = false, features = ["derive"] }
 crdts = "4.2.0"
 quickcheck = "0.9"
+log = "0.4.11"
 
 [dev-dependencies]
 quickcheck_macros = "0.9"

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -11,10 +11,10 @@ extern crate crdts;
 
 use crdt_tree::{Clock, OpMove, State, Tree, TreeId, TreeMeta};
 use crdts::Actor;
+use log::debug;
 use rand::Rng;
 use std::collections::HashMap;
 use std::env;
-use log::debug;
 
 #[derive(Debug)]
 struct Replica<ID: TreeId, TM: TreeMeta, A: Actor> {
@@ -58,9 +58,9 @@ impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
             if self.track_causally_stable_threshold {
                 let id = op.timestamp().actor_id();
                 match self.latest_time_by_replica.get(id) {
-                   Some(latest) if (latest <= op.timestamp()) => {
-                                        debug!("Clock not increased, current timestamp {:?}, provided is {:?}, dropping op!", latest, op.timestamp());
-                                    }
+                    Some(latest) if (latest <= op.timestamp()) => {
+                        debug!("Clock not increased, current timestamp {:?}, provided is {:?}, dropping op!", latest, op.timestamp());
+                    }
                     _ => {
                         self.latest_time_by_replica
                             .insert(op.timestamp().actor_id().clone(), op.timestamp().clone());
@@ -87,8 +87,8 @@ impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
         self.state.tree_mut()
     }
 
-    pub fn apply_ops(&mut self, ops: &Vec<OpMove<ID, TM, A>>) {
-        self.apply_ops_noref(ops.clone())
+    pub fn apply_ops(&mut self, ops: &[OpMove<ID, TM, A>]) {
+        self.apply_ops_noref(ops.to_vec())
     }
 
     /*
@@ -108,7 +108,7 @@ impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
 
         let mut v: Vec<&Clock<A>> = self.latest_time_by_replica.values().collect();
         v.sort_unstable_by(|a, b| a.cmp(b));
-        v.pop() 
+        v.pop()
     }
 
     pub fn truncate_log(&mut self) -> bool {
@@ -151,7 +151,7 @@ fn mktree_ops(
 
 fn apply_ops_to_replicas<ID, TM, A>(
     replicas: &mut Vec<Replica<ID, TM, A>>,
-    ops: &Vec<OpMove<ID, TM, A>>,
+    ops: &[OpMove<ID, TM, A>],
 ) where
     ID: TreeId,
     A: Actor + std::fmt::Debug,
@@ -207,7 +207,7 @@ where
     print_tree(repl1.tree(), root);
     println!("\n--replica_2 --");
     print_tree(repl2.tree(), root);
-    println!("");
+    println!();
 }
 
 // See paper for diagram.

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -108,7 +108,7 @@ impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
 
         let mut v: Vec<&Clock<A>> = self.latest_time_by_replica.values().collect();
         v.sort_unstable_by(|a, b| a.cmp(b));
-        if v.len() > 0 {
+        if !v.is_empty() {
             Some(v[0])
         } else {
             None

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -58,7 +58,7 @@ impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
             if self.track_causally_stable_threshold {
                 let id = op.timestamp().actor_id();
                 match self.latest_time_by_replica.get(id) {
-                    Some(latest) if (latest <= op.timestamp()) => {
+                    Some(latest) if (op.timestamp() <= latest) => {
                         debug!("Clock not increased, current timestamp {:?}, provided is {:?}, dropping op!", latest, op.timestamp());
                     }
                     _ => {
@@ -108,7 +108,11 @@ impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
 
         let mut v: Vec<&Clock<A>> = self.latest_time_by_replica.values().collect();
         v.sort_unstable_by(|a, b| a.cmp(b));
-        v.pop()
+        if v.len() > 0 {
+            Some(v[0])
+        } else {
+            None
+        }
     }
 
     pub fn truncate_log(&mut self) -> bool {

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -107,7 +107,7 @@ impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
         // is the causally stable threshold.
 
         let mut v: Vec<&Clock<A>> = self.latest_time_by_replica.values().collect();
-        v.sort_unstable_by(|a, b| a.cmp(b));
+        v.sort();
         if !v.is_empty() {
             Some(v[0])
         } else {

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -108,11 +108,8 @@ impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
 
         let mut v: Vec<&Clock<A>> = self.latest_time_by_replica.values().collect();
         v.sort();
-        if !v.is_empty() {
-            Some(v[0])
-        } else {
-            None
-        }
+        v.reverse(); // reverse, so last is lowest.
+        v.pop()
     }
 
     pub fn truncate_log(&mut self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,6 @@ pub mod treemeta;
 pub mod treenode;
 
 pub use self::{
-clock::Clock, logopmove::LogOpMove, opmove::OpMove, state::State, tree::Tree, treeid::TreeId,
-treemeta::TreeMeta, treenode::TreeNode,
+    clock::Clock, logopmove::LogOpMove, opmove::OpMove, state::State, tree::Tree, treeid::TreeId,
+    treemeta::TreeMeta, treenode::TreeNode,
 };

--- a/src/state.rs
+++ b/src/state.rs
@@ -34,7 +34,7 @@ use std::cmp::{Eq, Ordering, PartialEq};
 
 use super::{Clock, LogOpMove, OpMove, Tree, TreeId, TreeMeta, TreeNode};
 use crdts::{Actor, CmRDT};
-use log::info;
+use log::warn;
 
 /// `State`.  This is the primary interface for working with a
 /// Tree CRDT.
@@ -178,10 +178,12 @@ impl<ID: TreeId, TM: TreeMeta, A: Actor> State<ID, TM, A> {
             match op1.timestamp().cmp(&self.log_op_list[0].timestamp()) {
                 Ordering::Equal => {
                     // This case should never happen in normal operation
-                    // because it is required that all timestamps are unique.
+                    // because it is requirement/invariant that all
+                    // timestamps are unique.  However, uniqueness is not
+                    // strictly enforced in this impl.
                     // The crdt paper does not even check for this case.
-
-                    info!("Non unique timestamp!");
+                    // We just treat it as a no-op.
+                    warn!("op with timestamp equal to previous op ignored. (not applied).  Every op must have a unique timestamp.");
                 }
                 Ordering::Less => {
                     let logop = self.log_op_list.remove(0); // take from beginning of array

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -119,14 +119,14 @@ impl<ID: TreeId, TM: TreeMeta> Tree<ID, TM> {
 
     /// walks tree and calls Fn f for each node.
     /// not used by crdt algo.
-    /// 
+    ///
     /// walk uses a non-recursive algorithm, so calling
     /// it on a deep tree will not cause stack overflow.
     pub fn walk<F>(&self, parent_id: &ID, f: &F)
     where
         F: Fn(&Self, &ID, usize),
     {
-        let mut stack: Vec::<ID> = Vec::new();
+        let mut stack: Vec<ID> = Vec::new();
         stack.push(parent_id.clone());
         while !stack.is_empty() {
             if let Some(next) = stack.pop() {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -117,26 +117,25 @@ impl<ID: TreeId, TM: TreeMeta> Tree<ID, TM> {
         }
     }
 
-    /// walks tree and calls callback fn for each node.
+    /// walks tree and calls Fn f for each node.
     /// not used by crdt algo.
-    fn walk_worker<F>(&self, parent_id: &ID, f: &F, depth: usize)
-    where
-        F: Fn(&Self, &ID, usize),
-    {
-        f(self, parent_id, depth);
-        let children = self.children(parent_id);
-        for c in children {
-            self.walk_worker(&c, f, depth + 1);
-        }
-    }
-
-    /// walks tree and calls callback fn for each node.
-    /// not used by crdt algo.
+    /// 
+    /// walk uses a non-recursive algorithm, so calling
+    /// it on a deep tree will not cause stack overflow.
     pub fn walk<F>(&self, parent_id: &ID, f: &F)
     where
         F: Fn(&Self, &ID, usize),
     {
-        self.walk_worker(parent_id, f, 0)
+        let mut stack: Vec::<ID> = Vec::new();
+        stack.push(parent_id.clone());
+        while !stack.is_empty() {
+            if let Some(next) = stack.pop() {
+                f(self, &next, stack.len());
+                for child in self.children(&next) {
+                    stack.push(child)
+                }
+            }
+        }
     }
 
     /// parent | child

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -27,7 +27,7 @@ struct OperationList {
 impl Iterator for OperationList {
     type Item = OpMove<TypeId, TypeMeta, TypeActor>;
     fn next(&mut self) -> Option<OpMove<TypeId, TypeMeta, TypeActor>> {
-        self.ops.iter().next().cloned()
+        self.ops.get(0).cloned()
     }
 }
 
@@ -71,7 +71,7 @@ impl Arbitrary for OperationList {
             } else {
                 TypeId::arbitrary(g)
             };
-            nodes.push(next_id.clone());
+            nodes.push(next_id);
             let meta = TypeMeta::arbitrary(g);
 
             let op = OpMove::new(clock.tick(), parent_id, meta, next_id);

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -92,7 +92,7 @@ fn check_log_is_descending(s: &State<TypeId, TypeMeta, TypeActor>) -> bool {
         let first = &log[i];
         let second = &log[i + 1];
 
-        if !(first.timestamp() > second.timestamp()) {
+        if first.timestamp() <= second.timestamp() {
             return false;
         }
         i += 1;
@@ -121,7 +121,7 @@ fn parent_unique(s: &State<TypeId, TypeMeta, TypeActor>) -> bool {
     // Iterate all tree nodes and store count of each child_id, parent_id pair.
     // If any pair is found to exist more than once, the invariant is broken.
     for (child_id, tn) in s.tree().clone().into_iter() {
-        let key = (child_id.clone(), tn.parent_id().clone());
+        let key = (child_id, *tn.parent_id());
         let cnt = cnts.get(&key).unwrap_or(&0) + 1;
         cnts.insert(key, cnt);
 
@@ -143,8 +143,8 @@ fn state_from_ops(oplist: &OperationList) -> State<TypeId, TypeMeta, TypeActor> 
 
 // helper: checks if operation lists overlap, ie use the same actor_id.
 fn ops_overlap(o1: &OperationList, o2: &OperationList) -> bool {
-    o1.ops.len() > 0
-        && o2.ops.len() > 0
+    !o1.ops.is_empty()
+        && !o2.ops.is_empty()
         && o1.ops[0].timestamp().actor_id() == o2.ops[0].timestamp().actor_id()
 }
 

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -88,6 +88,9 @@ impl Arbitrary for OperationList {
 fn check_log_is_descending(s: &State<TypeId, TypeMeta, TypeActor>) -> bool {
     let mut i = 0;
     let log = s.log();
+    if log.is_empty() {
+        return true;
+    }
     while i < log.len() - 1 {
         let first = &log[i];
         let second = &log[i + 1];


### PR DESCRIPTION
Addresses some issues brought up in code review:

1. removes use of the inaccurate word "Exception" in a comment.

2. removes use of word "callback" and replaces with "Fn f" in a comment, to match argument type.

3. re-implements tree::walk() to use a non-recursive algo.

4. (maybe controversial) calls panic!(), only in debug build, for case when op.timestamp equals timestamp of previous op.

**Item 4 merits more discussion/explanation**

Note:  I wrote the below before seeing PR #8 which implements alternative (b) below.  I think that is a fine approach, though possibly/probably we should use warn!() instead of info!().   I will merge these PRs in the morning.

<strike>This is a condition that breaks the "all ops must have unique timestamp" invariant/contract as specified in Section 3.1 of the paper.  quote: *timestamps 't need to be globally unique and totally ordered (e.g. Lamport Timestamps).*  In fact, in the crdt paper algo, they do not even check for this case.

The State impl in this crate does not try to strictly enforce the unique timestamp invariant because a) it would require keeping an index of op timestamps and b) it's not even fully possible when log truncation is enabled.  So we kind of need to rely on callers behaving correctly.

The panic!() is not really necessary as the op can be ignored.  It is put there only as means of alert during development.   Alternatives would be to:  a) remove debug panic and do nothing at all,  b) log error instead of panic,  c) return a Result<(),Error>.

(a) is a little scary because there's more chance of a uniqueness bug slipping by in calling code.  Finding it would likely require testing 2+ replicas with ops out of order and comparing their state.

(b) simple, and a nice compromise between (a) and (c).  I'm good with it.

(c) I don't really wish to return a result/error because the general idea is that all ops get applied, and it is weird for caller to have to check result of applying each op for a disallowed-by-contract edge case.  Nothing the caller can do about that case anyway except maybe log an error.  Plus, would need to re-work a bunch of test and example code.  However, it can be done if necessary.

anyway, that's my thinking so far.