### PR TITLE
Adds a higher-level API with built-in lamport clock and causal threshold detection.

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -15,14 +15,369 @@ use rand::Rng;
 use std::collections::HashMap;
 use std::env;
 
+// define some concrete types to instantiate our Tree data structures with.
 type TypeId = u64;
 type TypeMeta<'a> = &'static str;
 type TypeActor = u64;
 
-// Returns operations representing a depth-first tree,
+// A simple main func to kickoff a demo or print-help.
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let demo = if args.len() > 1 { &args[1] } else { "" };
+
+    match demo {
+        "demo_concurrent_moves" => demo_concurrent_moves(),
+        "demo_concurrent_moves_cycle" => demo_concurrent_moves_cycle(),
+        "demo_truncate_log" => demo_truncate_log(),
+        "demo_walk_deep_tree" => demo_walk_deep_tree(),
+        "demo_move_to_trash" => demo_move_to_trash(),
+
+        _ => print_help(),
+    }
+}
+
+// Demo: Concurrent moves test from the paper.
+// See paper for diagram.
+//
+// Tests what happens when two peers move the same tree node to a different
+// location at the same time.  Upon applying eachother's ops, they must converge
+// to a common location.
+fn demo_concurrent_moves() {
+    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
+    let mut r2: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
+
+    let ids: HashMap<&str, TypeId> = [
+        ("root", new_id()),
+        ("a", new_id()),
+        ("b", new_id()),
+        ("c", new_id()),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    // Setup initial tree state.
+    let ops = r1.opmoves(vec![
+        (0, "root", ids["root"]),
+        (ids["root"], "a", ids["a"]),
+        (ids["root"], "b", ids["b"]),
+        (ids["root"], "c", ids["c"]),
+    ]);
+
+    r1.apply_ops_byref(&ops);
+    r2.apply_ops_byref(&ops);
+
+    println!("Initial tree state on both replicas");
+    print_tree(r1.tree(), &ids["root"]);
+
+    // replica_1 moves /root/a to /root/b
+    let repl1_ops = vec![r1.opmove(ids["b"], "a", ids["a"])];
+
+    // replica_2 "simultaneously" moves /root/a to /root/c
+    let repl2_ops = vec![r2.opmove(ids["c"], "a", ids["a"])];
+
+    // replica_1 applies his op, then merges op from replica_2
+    r1.apply_ops_byref(&repl1_ops);
+    println!("\nreplica_1 tree after move");
+    print_tree(r1.tree(), &ids["root"]);
+    r1.apply_ops_byref(&repl2_ops);
+
+    // replica_2 applies his op, then merges op from replica_1
+    r2.apply_ops_byref(&repl2_ops);
+    println!("\nreplica_2 tree after move");
+    print_tree(r2.tree(), &ids["root"]);
+    r2.apply_ops_byref(&repl1_ops);
+
+    // expected result: state is the same on both replicas
+    // and final path is /root/c/a because last-writer-wins
+    // and replica_2's op has a later timestamp.
+    //    if r1.state.is_equal(&r2.state) {
+    if r1.state() == r2.state() {
+        println!("\nreplica_1 state matches replica_2 state after each merges other's change.  conflict resolved!");
+        print_replica_trees(&r1, &r2, &ids["root"]);
+    } else {
+        println!("\nwarning: replica_1 state does not match replica_2 state after merge");
+        print_replica_trees(&r1, &r2, &ids["root"]);
+        println!("-- replica_1 state --");
+        println!("{:#?}", r1.state());
+        println!("\n-- replica_2 state --");
+        println!("{:#?}", r2.state());
+    }
+}
+
+// Demo: cycle test from the paper
+//
+// Tests what happen when two peers independently perform operations that would
+// introduce a cycle when combined.
+//
+// Upon applying eachother's ops, they must converge to a common location without
+// any cycles.
+fn demo_concurrent_moves_cycle() {
+    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
+    let mut r2: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
+
+    let ids: HashMap<&str, TypeId> = [
+        ("root", new_id()),
+        ("a", new_id()),
+        ("b", new_id()),
+        ("c", new_id()),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    // Setup initial tree state.
+    let ops = r1.opmoves(vec![
+        (0, "root", ids["root"]),
+        (ids["root"], "a", ids["a"]),
+        (ids["root"], "b", ids["b"]),
+        (ids["a"], "c", ids["c"]),
+    ]);
+
+    r1.apply_ops_byref(&ops);
+    r2.apply_ops_byref(&ops);
+
+    println!("Initial tree state on both replicas");
+    print_tree(r1.tree(), &ids["root"]);
+
+    // replica_1 moves /root/b to /root/a,  creating /root/a/b
+    let repl1_ops = r1.opmoves(vec![(ids["a"], "b", ids["b"])]);
+
+    // replica_2 "simultaneously" moves /root/a to /root/b, creating /root/b/a
+    let repl2_ops = r2.opmoves(vec![(ids["b"], "a", ids["a"])]);
+
+    // replica_1 applies his op, then merges op from replica_2
+    r1.apply_ops_byref(&repl1_ops);
+    println!("\nreplica_1 tree after move");
+    print_tree(r1.tree(), &ids["root"]);
+    r1.apply_ops_byref(&repl2_ops);
+
+    // replica_2 applies his op, then merges op from replica_1
+    r2.apply_ops_byref(&repl2_ops);
+    println!("\nreplica_2 tree after move");
+    print_tree(r2.tree(), &ids["root"]);
+    r2.apply_ops_byref(&repl1_ops);
+
+    // expected result: state is the same on both replicas
+    // and final path is /root/b/a because last-writer-wins
+    // and replica_2's op has a later timestamp.
+    if r1.state() == r2.state() {
+        println!("\nreplica_1 state matches replica_2 state after each merges other's change.  conflict resolved!");
+        print_replica_trees(&r1, &r2, &ids["root"]);
+    } else {
+        println!("\nwarning: replica_1 state does not match replica_2 state after merge");
+        print_replica_trees(&r1, &r2, &ids["root"]);
+        println!("-- replica_1 state --");
+        println!("{:#?}", r1.state());
+        println!("\n-- replica_2 state --");
+        println!("{:#?}", r2.state());
+    }
+}
+
+// Demo: Walk a deep tree
+//
+// This demonstrates creation of a deep tree which we then walk in depth-first
+// fashion.
+//
+// This particular tree contains 2^6-1 nodes and is up to 6 levels deep.
+fn demo_walk_deep_tree() {
+    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
+
+    let ids: HashMap<&str, TypeId> = [("root", new_id())].iter().cloned().collect();
+
+    // Generate initial tree state.
+    println!("generating ops...");
+    let mut ops = vec![(0, "root", ids["root"])];
+    mktree_ops(&mut ops, &mut r1, ids["root"], 2, 6); //  <-- max 6 levels deep.
+
+    println!("applying ops...");
+    let ops_len = ops.len();
+    r1.apply_ops_byref(&r1.opmoves(ops));
+
+    println!("walking tree...");
+    r1.tree().walk(&ids["root"], |tree, node_id, depth| {
+        if true {
+            let meta = match tree.find(node_id) {
+                Some(tn) => format!("{:?}", tn.metadata()),
+                None => format!("{:?}", node_id),
+            };
+            println!("{:indent$}{}", "", meta, indent = depth);
+        }
+    });
+
+    println!("\nnodes in tree: {}", ops_len);
+}
+
+/// Demonstrates log truncation
+///
+/// This requires that causally stable threshold tracking is enabled in `TreeReplica`
+fn demo_truncate_log() {
+    let mut replicas: Vec<TreeReplica<TypeId, TypeMeta, TypeActor>> = Vec::new();
+    let num_replicas = 5;
+
+    // start some replicas.
+    for _i in 0..num_replicas {
+        // pass true flag to enable causally stable threshold tracking
+        let r: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
+        replicas.push(r);
+    }
+
+    let root_id = new_id();
+
+    // Generate initial tree state.
+    let mut opmoves = vec![replicas[0].opmove(0, "root", root_id)];
+
+    println!("generating move operations...");
+
+    // generate some initial ops from all replicas.
+    for mut r in replicas.iter_mut() {
+        let finaldepth = rand::thread_rng().gen_range(3, 6);
+        let mut ops = vec![];
+        mktree_ops(&mut ops, &mut r, root_id, 2, finaldepth);
+        opmoves.extend(r.opmoves(ops));
+    }
+
+    // apply all ops to all replicas
+    println!(
+        "applying {} operations to all {} replicas...\n",
+        opmoves.len(),
+        replicas.len()
+    );
+    apply_ops_to_replicas(&mut replicas, &opmoves);
+
+    #[derive(Debug)]
+    struct Stat {
+        pub replica: TypeActor,
+        pub ops_before_truncate: usize,
+        pub ops_after_truncate: usize,
+    }
+
+    let mut stats: Vec<Stat> = Vec::new();
+    for r in replicas.iter_mut() {
+        println!("truncating log of replica {}...", r.id());
+        println!(
+            "causally stable threshold: {:?}\n",
+            r.causally_stable_threshold()
+        );
+        let ops_b4 = r.state().log().len();
+        r.truncate_log();
+        let ops_after = r.state().log().len();
+        stats.push(Stat {
+            replica: *r.id(),
+            ops_before_truncate: ops_b4,
+            ops_after_truncate: ops_after,
+        });
+    }
+
+    println!("-- Stats -- ");
+    println!("\n{:#?}", stats);
+}
+
+/// Demonstrates moving items to a Trash node outside the nominal root and then
+/// emptying the trash after the log is truncated.
+///
+/// This requires that causally stable threshold tracking is enabled in `TreeReplica`
+fn demo_move_to_trash() {
+    // pass true flag to enable causally stable threshold tracking
+    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
+    let mut r2: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
+
+    let ids: HashMap<&str, TypeId> = [
+        ("forest", new_id()),
+        ("trash", new_id()),
+        ("root", new_id()),
+        ("home", new_id()),
+        ("bob", new_id()),
+        ("project", new_id()),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    // Generate initial tree state.
+    //
+    // - forest
+    //   - trash
+    //   - root
+    //     - home
+    //       - bob
+    //         - project
+    let mut ops = vec![
+        (ids["forest"], "root", ids["root"]),
+        (ids["forest"], "trash", ids["trash"]),
+        (ids["root"], "home", ids["home"]),
+        (ids["home"], "bob", ids["bob"]),
+        (ids["bob"], "project", ids["project"]),
+    ];
+
+    // add some nodes under project
+    mktree_ops(&mut ops, &mut r1, ids["project"], 2, 3);
+    let opmoves = r1.opmoves(ops);
+    r1.apply_ops_byref(&opmoves);
+    r2.apply_ops_byref(&opmoves);
+
+    println!("Initial tree");
+    print_tree(r1.tree(), &ids["forest"]);
+
+    // move project to trash
+    let ops = vec![r1.opmove(ids["trash"], "project", ids["project"])];
+    r1.apply_ops_byref(&ops);
+    r2.apply_ops_byref(&ops);
+
+    println!("\nAfter project moved to trash (deleted) on both replicas");
+    print_tree(r1.tree(), &ids["forest"]);
+
+    // Initially, trashed nodes must be retained because a concurrent move
+    // operation may move them back out of the trash.
+    //
+    // Once the operation that moved a node to the trash is causally
+    // stable, we know that no future operations will refer to this node,
+    // and so the trashed node and its descendants can be discarded.
+    //
+    // note:  change r1.opmoves() to r2.opmoves() above to
+    //        make the causally stable threshold less than the trash operation
+    //        timestamp, which will cause this test to fail, ie hit the
+    //        "trash should not be emptied" condition.
+    let result = r2.causally_stable_threshold();
+    match result {
+        Some(cst) if cst < ops[0].timestamp() => {
+            println!(
+                "\ncausally stable threshold:\n{:#?}\n\ntrash operation:\n{:#?}",
+                cst,
+                ops[0].timestamp()
+            );
+            panic!("!error: causally stable threshold is less than trash operation timestamp");
+        }
+        None => panic!("!error: causally stable threshold not found"),
+        _ => {}
+    }
+
+    // empty trash
+    r1.tree_mut().rm_subtree(&ids["trash"], false);
+    println!("\nDelete op is now causally stable, so we can empty trash:");
+    print_tree(r1.tree(), &ids["forest"]);
+}
+
+fn print_help() {
+    let buf = "
+Usage: tree <demo>
+
+<demo> can be any of:
+  demo_concurrent_moves
+  demo_concurrent_moves_cycle
+  demo_truncate_log
+  demo_walk_deep_tree
+  demo_move_to_trash
+
+";
+    println!("{}", buf);
+}
+
+// Returns op tuples representing a depth-first tree,
 // with 2 children for each parent.
 fn mktree_ops(
-    ops: &mut Vec<OpMove<TypeId, TypeMeta, TypeActor>>,
+    ops: &mut Vec<(TypeId, TypeMeta, TypeActor)>,
     r: &mut TreeReplica<TypeId, TypeMeta, TypeActor>,
     parent_id: u64,
     depth: usize,
@@ -35,11 +390,12 @@ fn mktree_ops(
     for i in 0..2 {
         let name = if i == 0 { "a" } else { "b" };
         let child_id = new_id();
-        ops.push(r.opmove(parent_id, name, child_id));
+        ops.push((parent_id, name, child_id));
         mktree_ops(ops, r, child_id, depth + 1, max_depth);
     }
 }
 
+// applies each operation in ops to each replica in replicas.
 fn apply_ops_to_replicas<ID, TM, A>(
     replicas: &mut Vec<TreeReplica<ID, TM, A>>,
     ops: &[OpMove<ID, TM, A>],
@@ -49,7 +405,7 @@ fn apply_ops_to_replicas<ID, TM, A>(
     TM: TreeMeta,
 {
     for r in replicas.iter_mut() {
-        r.apply_ops(ops);
+        r.apply_ops_byref(ops);
     }
 }
 
@@ -88,8 +444,12 @@ where
     print_treenode(tree, root, 0, false);
 }
 
-fn print_replica_trees<ID, TM, A>(repl1: &TreeReplica<ID, TM, A>, repl2: &TreeReplica<ID, TM, A>, root: &ID)
-where
+// print trees for two replicas
+fn print_replica_trees<ID, TM, A>(
+    repl1: &TreeReplica<ID, TM, A>,
+    repl2: &TreeReplica<ID, TM, A>,
+    root: &ID,
+) where
     ID: TreeId + std::fmt::Debug,
     A: Actor + std::fmt::Debug,
     TM: TreeMeta + std::fmt::Debug,
@@ -99,334 +459,4 @@ where
     println!("\n--replica_2 --");
     print_tree(repl2.tree(), root);
     println!();
-}
-
-// See paper for diagram.
-fn test_concurrent_moves() {
-    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
-    let mut r2: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
-
-    let ids: HashMap<&str, TypeId> = [
-        ("root", 0),
-        ("a", new_id()),
-        ("b", new_id()),
-        ("c", new_id()),
-    ]
-    .iter()
-    .cloned()
-    .collect();
-
-    // Setup initial tree state.
-    let ops = vec![
-        r1.opmove(0, "root", ids["root"]),
-        r1.opmove(ids["root"], "a", ids["a"]),
-        r1.opmove(ids["root"], "b", ids["b"]),
-        r1.opmove(ids["root"], "c", ids["c"]),
-    ];
-
-    r1.apply_ops(&ops);
-    r2.apply_ops(&ops);
-
-    println!("Initial tree state on both replicas");
-    print_tree(r1.tree(), &ids["root"]);
-
-    // replica_1 moves /root/a to /root/b
-    let repl1_ops = vec![r1.opmove(ids["b"], "a", ids["a"])];
-
-    // replica_2 "simultaneously" moves /root/a to /root/c
-    let repl2_ops = vec![r2.opmove(ids["c"], "a", ids["a"])];
-
-    // replica_1 applies his op, then merges op from replica_2
-    r1.apply_ops(&repl1_ops);
-    println!("\nreplica_1 tree after move");
-    print_tree(r1.tree(), &ids["root"]);
-    r1.apply_ops(&repl2_ops);
-
-    // replica_2 applies his op, then merges op from replica_1
-    r2.apply_ops(&repl2_ops);
-    println!("\nreplica_2 tree after move");
-    print_tree(r2.tree(), &ids["root"]);
-    r2.apply_ops(&repl1_ops);
-
-    // expected result: state is the same on both replicas
-    // and final path is /root/c/a because last-writer-wins
-    // and replica_2's op has a later timestamp.
-    //    if r1.state.is_equal(&r2.state) {
-    if r1.state() == r2.state() {
-        println!("\nreplica_1 state matches replica_2 state after each merges other's change.  conflict resolved!");
-        print_replica_trees(&r1, &r2, &ids["root"]);
-    } else {
-        println!("\nwarning: replica_1 state does not match replica_2 state after merge");
-        print_replica_trees(&r1, &r2, &ids["root"]);
-        println!("-- replica_1 state --");
-        println!("{:#?}", r1.state());
-        println!("\n-- replica_2 state --");
-        println!("{:#?}", r2.state());
-    }
-}
-
-fn test_concurrent_moves_cycle() {
-    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
-    let mut r2: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
-
-    let ids: HashMap<&str, TypeId> = [
-        ("root", 0),
-        ("a", new_id()),
-        ("b", new_id()),
-        ("c", new_id()),
-    ]
-    .iter()
-    .cloned()
-    .collect();
-
-    // Setup initial tree state.
-    let ops = vec![
-        r1.opmove(0, "root", ids["root"]),
-        r1.opmove(ids["root"], "a", ids["a"]),
-        r1.opmove(ids["root"], "b", ids["b"]),
-        r1.opmove(ids["a"], "c", ids["c"]),
-    ];
-
-    r1.apply_ops(&ops);
-    r2.apply_ops(&ops);
-
-    println!("Initial tree state on both replicas");
-    print_tree(r1.tree(), &ids["root"]);
-
-    // replica_1 moves /root/b to /root/a
-    let repl1_ops = vec![r1.opmove(ids["a"], "b", ids["b"])];
-
-    // replica_2 "simultaneously" moves /root/a to /root/b
-    let repl2_ops = vec![r2.opmove(ids["b"], "a", ids["a"])];
-
-    // replica_1 applies his op, then merges op from replica_2
-    r1.apply_ops(&repl1_ops);
-    println!("\nreplica_1 tree after move");
-    print_tree(r1.tree(), &ids["root"]);
-    r1.apply_ops(&repl2_ops);
-
-    // replica_2 applies his op, then merges op from replica_1
-    r2.apply_ops(&repl2_ops);
-    println!("\nreplica_2 tree after move");
-    print_tree(r2.tree(), &ids["root"]);
-    r2.apply_ops(&repl1_ops);
-
-    // expected result: state is the same on both replicas
-    // and final path is /root/c/a because last-writer-wins
-    // and replica_2's op has a later timestamp.
-    if r1.state() == r2.state() {
-        println!("\nreplica_1 state matches replica_2 state after each merges other's change.  conflict resolved!");
-        print_replica_trees(&r1, &r2, &ids["root"]);
-    } else {
-        println!("\nwarning: replica_1 state does not match replica_2 state after merge");
-        print_replica_trees(&r1, &r2, &ids["root"]);
-        println!("-- replica_1 state --");
-        println!("{:#?}", r1.state());
-        println!("\n-- replica_2 state --");
-        println!("{:#?}", r2.state());
-    }
-}
-
-fn test_walk_deep_tree() {
-    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
-
-    let ids: HashMap<&str, TypeId> = [("root", 0)].iter().cloned().collect();
-
-    // Generate initial tree state.
-    println!("generating ops...");
-    let mut ops = vec![r1.opmove(0, "root", ids["root"])];
-    mktree_ops(&mut ops, &mut r1, ids["root"], 2, 13);
-
-    println!("applying ops...");
-    r1.apply_ops(&ops);
-
-    println!("walking tree...");
-    r1.tree().walk(&ids["root"], |tree, node_id, depth| {
-        if false {
-            let meta = match tree.find(node_id) {
-                Some(tn) => format!("{:?}", tn.metadata()),
-                None => format!("{:?}", node_id),
-            };
-            println!("{:indent$}{}", "", meta, indent = depth);
-        }
-    });
-
-    println!("\nnodes in tree: {}", ops.len());
-}
-
-fn test_truncate_log() {
-    let mut replicas: Vec<TreeReplica<TypeId, TypeMeta, TypeActor>> = Vec::new();
-    let num_replicas = 5;
-
-    // start some replicas.
-    for _i in 0..num_replicas {
-        let mut r: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
-        r.track_causally_stable_threshold(true); // needed for truncation
-        replicas.push(r);
-    }
-
-    let root_id = new_id();
-
-    // Generate initial tree state.
-    let mut ops = vec![replicas[0].opmove(0, "root", root_id)];
-
-    println!("generating move operations...");
-
-    // generate some initial ops from all replicas.
-    for mut r in replicas.iter_mut() {
-        let finaldepth = rand::thread_rng().gen_range(3, 6);
-        mktree_ops(&mut ops, &mut r, root_id, 2, finaldepth);
-    }
-
-    // apply all ops to all replicas
-    println!(
-        "applying {} operations to all {} replicas...\n",
-        ops.len(),
-        replicas.len()
-    );
-    apply_ops_to_replicas(&mut replicas, &ops);
-
-    #[derive(Debug)]
-    struct Stat {
-        pub replica: TypeActor,
-        pub ops_before_truncate: usize,
-        pub ops_after_truncate: usize,
-    }
-
-    let mut stats: Vec<Stat> = Vec::new();
-    for r in replicas.iter_mut() {
-        println!("truncating log of replica {}...", r.id());
-        println!(
-            "causally stable threshold: {:?}\n",
-            r.causally_stable_threshold()
-        );
-        let ops_b4 = r.state().log().len();
-        r.truncate_log();
-        let ops_after = r.state().log().len();
-        stats.push(Stat {
-            replica: *r.id(),
-            ops_before_truncate: ops_b4,
-            ops_after_truncate: ops_after,
-        });
-    }
-
-    println!("-- Stats -- ");
-    println!("\n{:#?}", stats);
-}
-
-fn test_move_to_trash() {
-    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
-    let mut r2: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
-
-    r1.track_causally_stable_threshold(true);
-    r2.track_causally_stable_threshold(true);
-
-    let ids: HashMap<&str, TypeId> = [
-        ("forest", new_id()),
-        ("trash", new_id()),
-        ("root", new_id()),
-        ("home", new_id()),
-        ("bob", new_id()),
-        ("project", new_id()),
-    ]
-    .iter()
-    .cloned()
-    .collect();
-
-    // Generate initial tree state.
-    //
-    // - forest
-    //   - trash
-    //   - root
-    //     - home
-    //       - bob
-    //         - project
-    let mut ops = vec![
-        r1.opmove(ids["forest"], "root", ids["root"]),
-        r1.opmove(ids["forest"], "trash", ids["trash"]),
-        r1.opmove(ids["root"], "home", ids["home"]),
-        r1.opmove(ids["home"], "bob", ids["bob"]),
-        r1.opmove(ids["bob"], "project", ids["project"]),
-    ];
-
-    // add some nodes under project
-    mktree_ops(&mut ops, &mut r1, ids["project"], 2, 3);
-    r1.apply_ops(&ops);
-    r2.apply_ops(&ops);
-
-    println!("Initial tree");
-    print_tree(r1.tree(), &ids["forest"]);
-
-    // move project to trash
-    let ops = vec![r1.opmove(
-        ids["trash"],
-        "project",
-        ids["project"],
-    )];
-    r1.apply_ops(&ops);
-    r2.apply_ops(&ops);
-
-    println!("\nAfter project moved to trash (deleted) on both replicas");
-    print_tree(r1.tree(), &ids["forest"]);
-
-    // Initially, trashed nodes must be retained because a concurrent move
-    // operation may move them back out of the trash.
-    //
-    // Once the operation that moved a node to the trash is causally
-    // stable, we know that no future operations will refer to this node,
-    // and so the trashed node and its descendants can be discarded.
-    //
-    // note:  change r1.tick() to r2.tick() for any of the above operations to
-    //        make the causally stable threshold less than the trash operation
-    //        timestamp, which will cause this test to fail, ie hit the
-    //        "trash should not be emptied" condition.
-    let result = r2.causally_stable_threshold();
-    match result {
-        Some(cst) if cst < ops[0].timestamp() => {
-            println!(
-                "\ncausally stable threshold:\n{:#?}\n\ntrash operation:\n{:#?}",
-                cst,
-                ops[0].timestamp()
-            );
-            panic!("!error: causally stable threshold is less than trash operation timestamp");
-        }
-        None => panic!("!error: causally stable threshold not found"),
-        _ => {}
-    }
-
-    // empty trash
-    r1.tree_mut().rm_subtree(&ids["trash"], false);
-    println!("\nDelete op is now causally stable, so we can empty trash:");
-    print_tree(r1.tree(), &ids["forest"]);
-}
-
-fn print_help() {
-    let buf = "
-Usage: tree <test>
-
-<test> can be any of:
-  test_concurrent_moves
-  test_concurrent_moves_cycle
-  test_truncate_log
-  test_walk_deep_tree
-  test_move_to_trash
-
-";
-    println!("{}", buf);
-}
-
-fn main() {
-    let args: Vec<String> = env::args().collect();
-
-    let test = if args.len() > 1 { &args[1] } else { "" };
-
-    match test {
-        "test_concurrent_moves" => test_concurrent_moves(),
-        "test_concurrent_moves_cycle" => test_concurrent_moves_cycle(),
-        "test_truncate_log" => test_truncate_log(),
-        "test_walk_deep_tree" => test_walk_deep_tree(),
-        "test_move_to_trash" => test_move_to_trash(),
-
-        _ => print_help(),
-    }
 }

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -9,131 +9,21 @@
 
 extern crate crdts;
 
-use crdt_tree::{Clock, OpMove, State, Tree, TreeId, TreeMeta};
+use crdt_tree::{OpMove, Tree, TreeId, TreeMeta, TreeReplica};
 use crdts::Actor;
-use log::debug;
 use rand::Rng;
 use std::collections::HashMap;
 use std::env;
 
-#[derive(Debug)]
-struct Replica<ID: TreeId, TM: TreeMeta, A: Actor> {
-    id: A,                   // Actor representing this replica.  (globally unique id).
-    state: State<ID, TM, A>, // Tree state
-    time: Clock<A>,          // Lamport Clock for this replica/tree.
-
-    // These are both for tracking causally stable threshold.
-    //  (needed for truncating logs, emptying trash)
-    latest_time_by_replica: HashMap<A, Clock<A>>,
-    track_causally_stable_threshold: bool,
-}
-
-impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> Replica<ID, TM, A> {
-    pub fn new(id: A) -> Self {
-        Self {
-            id: id.clone(),
-            state: State::new(),
-            time: Clock::<A>::new(id, None),
-            latest_time_by_replica: HashMap::<A, Clock<A>>::new(),
-            track_causally_stable_threshold: false,
-        }
-    }
-
-    pub fn track_causally_stable_threshold(&mut self, flag: bool) {
-        self.track_causally_stable_threshold = flag;
-    }
-    #[inline]
-    pub fn id(&self) -> &A {
-        &self.id
-    }
-
-    pub fn apply_ops_noref(&mut self, ops: Vec<OpMove<ID, TM, A>>) {
-        for op in ops.clone() {
-            self.time = self.time.merge(op.timestamp());
-
-            // store latest timestamp for this actor.
-            // This is only needed for calculation of
-            // causally_stable_threshold.  If that is not
-            // required, it needn't execute.
-            if self.track_causally_stable_threshold {
-                let id = op.timestamp().actor_id();
-                match self.latest_time_by_replica.get(id) {
-                    Some(latest) if (op.timestamp() <= latest) => {
-                        debug!("Clock not increased, current timestamp {:?}, provided is {:?}, dropping op!", latest, op.timestamp());
-                    }
-                    _ => {
-                        self.latest_time_by_replica
-                            .insert(op.timestamp().actor_id().clone(), op.timestamp().clone());
-                    }
-                };
-            }
-
-            self.state.apply_op(op);
-        }
-    }
-
-    #[inline]
-    pub fn state(&self) -> &State<ID, TM, A> {
-        &self.state
-    }
-
-    #[inline]
-    pub fn tree(&self) -> &Tree<ID, TM> {
-        self.state.tree()
-    }
-
-    #[inline]
-    pub fn tree_mut(&mut self) -> &mut Tree<ID, TM> {
-        self.state.tree_mut()
-    }
-
-    pub fn apply_ops(&mut self, ops: &[OpMove<ID, TM, A>]) {
-        self.apply_ops_noref(ops.to_vec())
-    }
-
-    /*
-        // applies ops from a log.  useful for log replay.
-        fn apply_log_ops(&mut self, log_ops: &Vec<LogOpMove<TM, A>>) {
-            let mut ops: Vec::<OpMove<TM, A>> = Vec::new();
-            for log_op in log_ops {
-                ops.push(OpMove::from_log_op_move(log_op));
-            }
-            self.apply_ops(&ops);
-        }
-    */
-
-    pub fn causally_stable_threshold(&self) -> Option<&Clock<A>> {
-        // The minimum of latest timestamp from each replica
-        // is the causally stable threshold.
-
-        let mut v: Vec<&Clock<A>> = self.latest_time_by_replica.values().collect();
-        v.sort();
-        v.reverse(); // reverse, so last is lowest.
-        v.pop()
-    }
-
-    pub fn truncate_log(&mut self) -> bool {
-        let result = self.causally_stable_threshold();
-        match result.cloned() {
-            Some(t) => self.state.truncate_log_before(&t),
-            None => false,
-        }
-    }
-
-    pub fn tick(&mut self) -> Clock<A> {
-        self.time.tick()
-    }
-}
-
 type TypeId = u64;
-type TypeMeta<'a> = &'a str;
+type TypeMeta<'a> = &'static str;
 type TypeActor = u64;
 
 // Returns operations representing a depth-first tree,
 // with 2 children for each parent.
 fn mktree_ops(
     ops: &mut Vec<OpMove<TypeId, TypeMeta, TypeActor>>,
-    r: &mut Replica<TypeId, TypeMeta, TypeActor>,
+    r: &mut TreeReplica<TypeId, TypeMeta, TypeActor>,
     parent_id: u64,
     depth: usize,
     max_depth: usize,
@@ -145,13 +35,13 @@ fn mktree_ops(
     for i in 0..2 {
         let name = if i == 0 { "a" } else { "b" };
         let child_id = new_id();
-        ops.push(OpMove::new(r.tick(), parent_id, name, child_id));
+        ops.push(r.opmove(parent_id, name, child_id));
         mktree_ops(ops, r, child_id, depth + 1, max_depth);
     }
 }
 
 fn apply_ops_to_replicas<ID, TM, A>(
-    replicas: &mut Vec<Replica<ID, TM, A>>,
+    replicas: &mut Vec<TreeReplica<ID, TM, A>>,
     ops: &[OpMove<ID, TM, A>],
 ) where
     ID: TreeId,
@@ -198,7 +88,7 @@ where
     print_treenode(tree, root, 0, false);
 }
 
-fn print_replica_trees<ID, TM, A>(repl1: &Replica<ID, TM, A>, repl2: &Replica<ID, TM, A>, root: &ID)
+fn print_replica_trees<ID, TM, A>(repl1: &TreeReplica<ID, TM, A>, repl2: &TreeReplica<ID, TM, A>, root: &ID)
 where
     ID: TreeId + std::fmt::Debug,
     A: Actor + std::fmt::Debug,
@@ -213,8 +103,8 @@ where
 
 // See paper for diagram.
 fn test_concurrent_moves() {
-    let mut r1: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
-    let mut r2: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
+    let mut r2: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
 
     let ids: HashMap<&str, TypeId> = [
         ("root", 0),
@@ -228,10 +118,10 @@ fn test_concurrent_moves() {
 
     // Setup initial tree state.
     let ops = vec![
-        OpMove::new(r1.tick(), 0, "root", ids["root"]),
-        OpMove::new(r1.tick(), ids["root"], "a", ids["a"]),
-        OpMove::new(r1.tick(), ids["root"], "b", ids["b"]),
-        OpMove::new(r1.tick(), ids["root"], "c", ids["c"]),
+        r1.opmove(0, "root", ids["root"]),
+        r1.opmove(ids["root"], "a", ids["a"]),
+        r1.opmove(ids["root"], "b", ids["b"]),
+        r1.opmove(ids["root"], "c", ids["c"]),
     ];
 
     r1.apply_ops(&ops);
@@ -241,10 +131,10 @@ fn test_concurrent_moves() {
     print_tree(r1.tree(), &ids["root"]);
 
     // replica_1 moves /root/a to /root/b
-    let repl1_ops = vec![OpMove::new(r1.tick(), ids["b"], "a", ids["a"])];
+    let repl1_ops = vec![r1.opmove(ids["b"], "a", ids["a"])];
 
     // replica_2 "simultaneously" moves /root/a to /root/c
-    let repl2_ops = vec![OpMove::new(r2.tick(), ids["c"], "a", ids["a"])];
+    let repl2_ops = vec![r2.opmove(ids["c"], "a", ids["a"])];
 
     // replica_1 applies his op, then merges op from replica_2
     r1.apply_ops(&repl1_ops);
@@ -262,22 +152,22 @@ fn test_concurrent_moves() {
     // and final path is /root/c/a because last-writer-wins
     // and replica_2's op has a later timestamp.
     //    if r1.state.is_equal(&r2.state) {
-    if r1.state == r2.state {
+    if r1.state() == r2.state() {
         println!("\nreplica_1 state matches replica_2 state after each merges other's change.  conflict resolved!");
         print_replica_trees(&r1, &r2, &ids["root"]);
     } else {
         println!("\nwarning: replica_1 state does not match replica_2 state after merge");
         print_replica_trees(&r1, &r2, &ids["root"]);
         println!("-- replica_1 state --");
-        println!("{:#?}", r1.state);
+        println!("{:#?}", r1.state());
         println!("\n-- replica_2 state --");
-        println!("{:#?}", r2.state);
+        println!("{:#?}", r2.state());
     }
 }
 
 fn test_concurrent_moves_cycle() {
-    let mut r1: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
-    let mut r2: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
+    let mut r2: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
 
     let ids: HashMap<&str, TypeId> = [
         ("root", 0),
@@ -291,10 +181,10 @@ fn test_concurrent_moves_cycle() {
 
     // Setup initial tree state.
     let ops = vec![
-        OpMove::new(r1.tick(), 0, "root", ids["root"]),
-        OpMove::new(r1.tick(), ids["root"], "a", ids["a"]),
-        OpMove::new(r1.tick(), ids["root"], "b", ids["b"]),
-        OpMove::new(r1.tick(), ids["a"], "c", ids["c"]),
+        r1.opmove(0, "root", ids["root"]),
+        r1.opmove(ids["root"], "a", ids["a"]),
+        r1.opmove(ids["root"], "b", ids["b"]),
+        r1.opmove(ids["a"], "c", ids["c"]),
     ];
 
     r1.apply_ops(&ops);
@@ -304,10 +194,10 @@ fn test_concurrent_moves_cycle() {
     print_tree(r1.tree(), &ids["root"]);
 
     // replica_1 moves /root/b to /root/a
-    let repl1_ops = vec![OpMove::new(r1.tick(), ids["a"], "b", ids["b"])];
+    let repl1_ops = vec![r1.opmove(ids["a"], "b", ids["b"])];
 
     // replica_2 "simultaneously" moves /root/a to /root/b
-    let repl2_ops = vec![OpMove::new(r2.tick(), ids["b"], "a", ids["a"])];
+    let repl2_ops = vec![r2.opmove(ids["b"], "a", ids["a"])];
 
     // replica_1 applies his op, then merges op from replica_2
     r1.apply_ops(&repl1_ops);
@@ -324,27 +214,27 @@ fn test_concurrent_moves_cycle() {
     // expected result: state is the same on both replicas
     // and final path is /root/c/a because last-writer-wins
     // and replica_2's op has a later timestamp.
-    if r1.state == r2.state {
+    if r1.state() == r2.state() {
         println!("\nreplica_1 state matches replica_2 state after each merges other's change.  conflict resolved!");
         print_replica_trees(&r1, &r2, &ids["root"]);
     } else {
         println!("\nwarning: replica_1 state does not match replica_2 state after merge");
         print_replica_trees(&r1, &r2, &ids["root"]);
         println!("-- replica_1 state --");
-        println!("{:#?}", r1.state);
+        println!("{:#?}", r1.state());
         println!("\n-- replica_2 state --");
-        println!("{:#?}", r2.state);
+        println!("{:#?}", r2.state());
     }
 }
 
 fn test_walk_deep_tree() {
-    let mut r1: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
 
     let ids: HashMap<&str, TypeId> = [("root", 0)].iter().cloned().collect();
 
     // Generate initial tree state.
     println!("generating ops...");
-    let mut ops = vec![OpMove::new(r1.tick(), 0, "root", ids["root"])];
+    let mut ops = vec![r1.opmove(0, "root", ids["root"])];
     mktree_ops(&mut ops, &mut r1, ids["root"], 2, 13);
 
     println!("applying ops...");
@@ -365,12 +255,12 @@ fn test_walk_deep_tree() {
 }
 
 fn test_truncate_log() {
-    let mut replicas: Vec<Replica<TypeId, TypeMeta, TypeActor>> = Vec::new();
+    let mut replicas: Vec<TreeReplica<TypeId, TypeMeta, TypeActor>> = Vec::new();
     let num_replicas = 5;
 
     // start some replicas.
     for _i in 0..num_replicas {
-        let mut r: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+        let mut r: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
         r.track_causally_stable_threshold(true); // needed for truncation
         replicas.push(r);
     }
@@ -378,7 +268,7 @@ fn test_truncate_log() {
     let root_id = new_id();
 
     // Generate initial tree state.
-    let mut ops = vec![OpMove::new(replicas[0].tick(), 0, "root", root_id)];
+    let mut ops = vec![replicas[0].opmove(0, "root", root_id)];
 
     println!("generating move operations...");
 
@@ -425,8 +315,8 @@ fn test_truncate_log() {
 }
 
 fn test_move_to_trash() {
-    let mut r1: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
-    let mut r2: Replica<TypeId, TypeMeta, TypeActor> = Replica::new(new_id());
+    let mut r1: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
+    let mut r2: TreeReplica<TypeId, TypeMeta, TypeActor> = TreeReplica::new(new_id());
 
     r1.track_causally_stable_threshold(true);
     r2.track_causally_stable_threshold(true);
@@ -452,11 +342,11 @@ fn test_move_to_trash() {
     //       - bob
     //         - project
     let mut ops = vec![
-        OpMove::new(r1.tick(), ids["forest"], "root", ids["root"]),
-        OpMove::new(r1.tick(), ids["forest"], "trash", ids["trash"]),
-        OpMove::new(r1.tick(), ids["root"], "home", ids["home"]),
-        OpMove::new(r1.tick(), ids["home"], "bob", ids["bob"]),
-        OpMove::new(r1.tick(), ids["bob"], "project", ids["project"]),
+        r1.opmove(ids["forest"], "root", ids["root"]),
+        r1.opmove(ids["forest"], "trash", ids["trash"]),
+        r1.opmove(ids["root"], "home", ids["home"]),
+        r1.opmove(ids["home"], "bob", ids["bob"]),
+        r1.opmove(ids["bob"], "project", ids["project"]),
     ];
 
     // add some nodes under project
@@ -468,8 +358,7 @@ fn test_move_to_trash() {
     print_tree(r1.tree(), &ids["forest"]);
 
     // move project to trash
-    let ops = vec![OpMove::new(
-        r1.tick(),
+    let ops = vec![r1.opmove(
         ids["trash"],
         "project",
         ids["project"],

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -7,25 +7,6 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-//! Implements Lamport Clock
-//!
-//! For usage/examples, see:
-//!   examples/tree.rs
-//!   test/tree.rs
-//!
-//! This code aims to be an accurate implementation of the
-//! tree crdt described in:
-//!
-//! "A highly-available move operation for replicated trees
-//! and distributed filesystems" [1] by Martin Klepmann, et al.
-//!
-//! [1] https://martin.kleppmann.com/papers/move-op.pdf
-//!
-//! For clarity, data structures in this implementation are named
-//! the same as in the paper (State, Tree) or close to
-//! (OpMove --> Move, LogOpMove --> LogOp).  Some are not explicitly
-//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
-
 use crdts::quickcheck::{Arbitrary, Gen};
 use serde::{Deserialize, Serialize};
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
@@ -33,7 +14,7 @@ use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use crdts::Actor;
 use std::hash::{Hash, Hasher};
 
-/// lamport clock + actor
+/// Implements a `Lamport Clock` consisting of an `Actor` and an integer counter.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Clock<A: Actor> {
     actor_id: A,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 //! Implements Tree Conflict-Free Replicated Data Type (CRDT).
 //!
 //! For usage/examples, see:
-//!   examples/tree.rs
-//!   test/tree.rs
+//!   examples/demo.rs
+//!   tests/tree.rs
 //!
 //! This code aims to be an accurate implementation of the
 //! tree crdt described in:
@@ -27,34 +27,29 @@
 //! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
 #![deny(missing_docs)]
 
-/// This module contains a Tree.
-pub mod tree;
+mod tree;
+pub use self::tree::Tree;
 
-/// This module contains State.
-pub mod state;
+mod state;
+pub use self::state::State;
 
-/// This module contains a Clock.
-pub mod clock;
+mod clock;
+pub use self::clock::Clock;
 
-/// This module contains OpMove.
-pub mod opmove;
+mod opmove;
+pub use self::opmove::OpMove;
 
-/// This module contains `LogOpMove`.
-pub mod logopmove;
+mod logopmove;
+pub use self::logopmove::LogOpMove;
 
-/// This module contains `TreeId`.
-pub mod treeid;
+mod treeid;
+pub use self::treeid::TreeId;
 
-/// This module contains `TreeMeta`.
-pub mod treemeta;
+mod treemeta;
+pub use self::treemeta::TreeMeta;
 
-/// This module contains `TreeNode`.
-pub mod treenode;
+mod treenode;
+pub use self::treenode::TreeNode;
 
-/// This module contains `TreeReplica`.
-pub mod treereplica;
-
-pub use self::{
-    clock::Clock, logopmove::LogOpMove, opmove::OpMove, state::State, tree::Tree, treeid::TreeId,
-    treemeta::TreeMeta, treenode::TreeNode, treereplica::TreeReplica,
-};
+mod treereplica;
+pub use self::treereplica::TreeReplica;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,10 @@ pub mod treemeta;
 /// This module contains `TreeNode`.
 pub mod treenode;
 
+/// This module contains `TreeReplica`.
+pub mod treereplica;
+
 pub use self::{
     clock::Clock, logopmove::LogOpMove, opmove::OpMove, state::State, tree::Tree, treeid::TreeId,
-    treemeta::TreeMeta, treenode::TreeNode,
+    treemeta::TreeMeta, treenode::TreeNode, treereplica::TreeReplica,
 };

--- a/src/logopmove.rs
+++ b/src/logopmove.rs
@@ -7,32 +7,15 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-//! Implements `LogOpMove`, a log entry used by `State`
-//!
-//! For usage/examples, see:
-//!   examples/tree.rs
-//!   test/tree.rs
-//!
-//! This code aims to be an accurate implementation of the
-//! tree crdt described in:
-//!
-//! "A highly-available move operation for replicated trees
-//! and distributed filesystems" [1] by Martin Klepmann, et al.
-//!
-//! [1] <https://martin.kleppmann.com/papers/move-op.pdf>
-//!
-//! For clarity, data structures in this implementation are named
-//! the same as in the paper (`State`, `Tree`) or close to
-//! (`OpMove` --> `Move`, `LogOpMove` --> `LogOp`).  Some are not explicitly
-//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
-
 use serde::{Deserialize, Serialize};
 use std::cmp::{Eq, PartialEq};
 
 use super::{Clock, OpMove, TreeId, TreeMeta, TreeNode};
 use crdts::Actor;
 
-/// From the paper:
+/// Implements `LogOpMove`, a log entry used by `State`
+///
+/// From the paper[1]:
 /// ----
 /// In order to correctly apply move operations, a replica needs
 /// to maintain not only the current state of the tree, but also
@@ -53,6 +36,7 @@ use crdts::Actor;
 /// such that (p', m', c') E tree, then `oldp` is set to `Some(p', m')`.
 /// The `get_parent()` function implements this.
 /// ----
+/// [1] <https://martin.kleppmann.com/papers/move-op.pdf>
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LogOpMove<ID: TreeId, TM: TreeMeta, A: Actor> {
     // an operation that is being logged.

--- a/src/opmove.rs
+++ b/src/opmove.rs
@@ -7,27 +7,6 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-//! Implements OpMove, the only way to manipulate Tree data.
-//!
-//! OpMove are applied via State::apply_op()
-//!
-//! For usage/examples, see:
-//!   examples/tree.rs
-//!   test/tree.rs
-//!
-//! This code aims to be an accurate implementation of the
-//! tree crdt described in:
-//!
-//! "A highly-available move operation for replicated trees
-//! and distributed filesystems" [1] by Martin Klepmann, et al.
-//!
-//! [1] https://martin.kleppmann.com/papers/move-op.pdf
-//!
-//! For clarity, data structures in this implementation are named
-//! the same as in the paper (State, Tree) or close to
-//! (OpMove --> Move, LogOpMove --> LogOp).  Some are not explicitly
-//! named in the paper, such as TreeId, TreeMeta, TreeNode, Clock.
-
 use serde::{Deserialize, Serialize};
 use std::cmp::{Eq, PartialEq};
 
@@ -36,7 +15,12 @@ use crdts::quickcheck::{Arbitrary, Gen};
 use crdts::Actor;
 use std::hash::Hash;
 
-/// From the paper:
+/// Implements `OpMove`, the only way to manipulate tree data.
+///
+/// `OpMove` are applied via `State`::apply_op() or at a higher
+/// level via `TreeReplica`::apply_op()
+///
+/// From the paper[1]:
 /// ----
 /// We allow the tree to be updated in three ways: by creating
 /// a new child of any parent node, by deleting a node, or by
@@ -80,6 +64,7 @@ use std::hash::Hash;
 /// changes, and apply these operations using the algorithm
 /// described...
 /// ----
+/// [1] https://martin.kleppmann.com/papers/move-op.pdf
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct OpMove<ID: TreeId, TM: TreeMeta, A: Actor> {
     /// lamport clock + actor

--- a/src/treeid.rs
+++ b/src/treeid.rs
@@ -7,25 +7,6 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-//! Implements `TreeId`, a trait for representing `Tree` (Node) Identifiers
-//!
-//! For usage/examples, see:
-//!   examples/tree.rs
-//!   test/tree.rs
-//!
-//! This code aims to be an accurate implementation of the
-//! tree crdt described in:
-//!
-//! "A highly-available move operation for replicated trees
-//! and distributed filesystems" [1] by Martin Klepmann, et al.
-//!
-//! [1] <https://martin.kleppmann.com/papers/move-op.pdf>
-//!
-//! For clarity, data structures in this implementation are named
-//! the same as in the paper (State, Tree) or close to
-//! (`OpMove` --> `Move`, `LogOpMove` --> `LogOp`).  Some are not explicitly
-//! named in the paper, such as `TreeId`, `TreeMeta`, `TreeNode`, `Clock`.
-
 use std::hash::Hash;
 
 /// `TreeId` trait. `TreeId` are unique identifiers for each node in a tree.

--- a/src/treemeta.rs
+++ b/src/treemeta.rs
@@ -7,26 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-//! Implements `TreeMeta`, a trait for representing `Tree` (`Node`) metadata
-//!
-//! For usage/examples, see:
-//!   examples/tree.rs
-//!   test/tree.rs
-//!
-//! This code aims to be an accurate implementation of the
-//! tree crdt described in:
-//!
-//! "A highly-available move operation for replicated trees
-//! and distributed filesystems" [1] by Martin Klepmann, et al.
-//!
-//! [1] <https://martin.kleppmann.com/papers/move-op.pdf>
-//!
-//! For clarity, data structures in this implementation are named
-//! the same as in the paper (State, Tree) or close to
-//! (`OpMove` --> `Move`, `LogOpMove` --> `LogOp`).  Some are not explicitly
-//! named in the paper, such as `TreeId`, `TreeMeta`, `TreeNode`, `Clock`.
-
-/// `TreeMeta` trait. `TreeMeta` are application-defined pieces of data that are stored
-/// with each node in the Tree.
+/// `TreeMeta` represent the app-defined data that an application stores in each node
+/// of the tree.
 pub trait TreeMeta: Clone {}
 impl<TM: Clone> TreeMeta for TM {}

--- a/src/treenode.rs
+++ b/src/treenode.rs
@@ -7,33 +7,14 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-//! Implements `TreeNode`, ie a node that is stored in a `Tree`.
-//!
-//! For usage/examples, see:
-//!   examples/tree.rs
-//!   test/tree.rs
-//!
-//! This code aims to be an accurate implementation of the
-//! tree crdt described in:
-//!
-//! "A highly-available move operation for replicated trees
-//! and distributed filesystems" [1] by Martin Klepmann, et al.
-//!
-//! [1] <https://martin.kleppmann.com/papers/move-op.pdf>
-//!
-//! For clarity, data structures in this implementation are named
-//! the same as in the paper (`State`, `Tree`) or close to
-//! (`OpMove` --> `Move`, `LogOpMove` --> `LogOp`).  Some are not explicitly
-//! named in the paper, such as `TreeId`, `TreeMeta`, `TreeNode`, `Clock`.
-
 use serde::{Deserialize, Serialize};
 use std::cmp::{Eq, PartialEq};
 
 use super::{TreeId, TreeMeta};
 
-/// Represents a Node in a Tree.
+/// `TreeNode` is a node that is stored in a `Tree`.
 ///
-/// Logically, each Node consists of a triple `(parent_id, metadata, child_id)`.
+/// Logically, each `TreeNode` consists of a triple `(parent_id, metadata, child_id)`.
 /// However, in this implementation, the `child_id` is stored as the
 /// key in `Tree::triples HashMap<ID, TreeNode>`
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/treereplica.rs
+++ b/src/treereplica.rs
@@ -1,0 +1,181 @@
+// Copyright 2020 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+extern crate crdts;
+
+use super::{Clock, LogOpMove, OpMove, State, Tree, TreeId, TreeMeta};
+use crdts::Actor;
+use log::debug;
+use std::collections::HashMap;
+
+/// `TreeReplica` holds tree `State` plus lamport timestamp (actor + counter)
+///
+/// It can optionally keep track of the latest timestamp for each
+/// replica which is needed for calculating the causally stable threshold which
+/// is in turn needed for log truncation.
+///
+/// `TreeReplica` is a higher-level interface to the Tree CRDT and is tied to a
+/// particular actor/peer.
+///
+/// `State` is a lower-level interface to the Tree CRDT and is not tied to any
+/// actor/peer.
+#[derive(Debug)]
+pub struct TreeReplica<ID: TreeId, TM: TreeMeta, A: Actor> {
+    state: State<ID, TM, A>, // Tree state
+    time: Clock<A>,          // Lamport Clock for this replica/tree.
+
+    latest_time_by_replica: HashMap<A, Clock<A>>,
+}
+
+impl<ID: TreeId, TM: TreeMeta, A: Actor + std::fmt::Debug> TreeReplica<ID, TM, A> {
+    /// returns new TreeReplica
+    pub fn new(id: A) -> Self {
+        Self {
+            state: State::new(),
+            time: Clock::<A>::new(id, None),
+            latest_time_by_replica: HashMap::<A, Clock<A>>::new(),
+        }
+    }
+
+    /// Generates an OpMove
+    ///
+    /// Note that OpMove::timestamp is incremented from TreeReplica::time.
+    /// TreeReplica::time is not updated until ::apply_op() is called.
+    ///
+    /// Therefore, multiple ops generated with this method may share the same
+    /// timestamp, and only one can be sucessfully applied.
+    ///
+    /// To generate multiple ops before calling ::apply_op(), use ::opmoves() instead.
+    pub fn opmove(&self, parent_id: ID, metadata: TM, child_id: ID) -> OpMove<ID, TM, A> {
+        OpMove::new(self.time.inc(), parent_id, metadata, child_id)
+    }
+
+    /// Generates a list of OpMove from a list of tuples (child_id, metadata, parent_id)
+    ///
+    /// Each OpMove::timestamp will be greater than the previous op in the returned list.
+    /// Therefore, these operations can be successfully applied via ::apply_op() without
+    /// timestamp collision.
+    pub fn opmoves(&self, ops: Vec<(ID, TM, ID)>) -> Vec<OpMove<ID, TM, A>> {
+        let mut time = self.time.clone();
+
+        let mut opmoves = vec![];
+
+        for op in ops {
+            opmoves.push(OpMove::new(time.tick(), op.0, op.1, op.2));
+        }
+        opmoves
+    }
+
+    /// Returns actor ID for this replica
+    #[inline]
+    pub fn id(&self) -> &A {
+        self.time.actor_id()
+    }
+
+    /// Returns the latest lamport time seen by this replica
+    #[inline]
+    pub fn time(&self) -> &Clock<A> {
+        &self.time
+    }
+
+    /// Returns Tree State reference
+    #[inline]
+    pub fn state(&self) -> &State<ID, TM, A> {
+        &self.state
+    }
+
+    /// Returns Tree reference
+    #[inline]
+    pub fn tree(&self) -> &Tree<ID, TM> {
+        self.state.tree()
+    }
+
+    /// Returns mutable Tree reference
+    ///
+    /// Warning: this is dangerous.  Normally the `Tree` should
+    /// not be mutated directly.
+    ///
+    /// See the demo_move_to_trash in examples/demo.rs for a
+    /// use-case, only after log truncation has been performed.
+    #[inline]
+    pub fn tree_mut(&mut self) -> &mut Tree<ID, TM> {
+        self.state.tree_mut()
+    }
+
+    /// Applies single operation to `State` and updates our time clock
+    ///
+    /// Also records latest timestamp for each replica if
+    /// track_causally_stable_threshold flag is set.
+    pub fn apply_op(&mut self, op: OpMove<ID, TM, A>) {
+        self.time = self.time.merge(op.timestamp());
+
+        // store latest timestamp for this actor.
+        // This is only needed for calculation of causally_stable_threshold.
+        let id = op.timestamp().actor_id();
+        match self.latest_time_by_replica.get(id) {
+            Some(latest) if (op.timestamp() <= latest) => {
+                debug!(
+                    "Clock not increased, current timestamp {:?}, provided is {:?}, dropping op!",
+                    latest,
+                    op.timestamp()
+                );
+            }
+            _ => {
+                self.latest_time_by_replica
+                    .insert(op.timestamp().actor_id().clone(), op.timestamp().clone());
+            }
+        };
+
+        self.state.apply_op(op);
+    }
+
+    /// Applies list of operations
+    pub fn apply_ops(&mut self, ops: Vec<OpMove<ID, TM, A>>) {
+        for op in ops {
+            self.apply_op(op);
+        }
+    }
+
+    /// Applies list of operations without taking ownership
+    pub fn apply_ops_byref(&mut self, ops: &[OpMove<ID, TM, A>]) {
+        self.apply_ops(ops.to_vec())
+    }
+
+    /// applies op from a log.  useful for log replay.
+    pub fn apply_log_op(&mut self, log_op: LogOpMove<ID, TM, A>) {
+        self.apply_op(log_op.into());
+    }
+
+    /// applies ops from a log.  useful for log replay.
+    pub fn apply_log_ops(&mut self, log_ops: Vec<LogOpMove<ID, TM, A>>) {
+        for log_op in log_ops {
+            self.apply_log_op(log_op);
+        }
+    }
+
+    /// returns the causally stable threshold
+    pub fn causally_stable_threshold(&self) -> Option<&Clock<A>> {
+        // The minimum of latest timestamp from each replica
+        // is the causally stable threshold.
+
+        let mut v: Vec<&Clock<A>> = self.latest_time_by_replica.values().collect();
+        v.sort();
+        v.reverse(); // reverse, so last is lowest.
+        v.pop()
+    }
+
+    /// truncates log
+    pub fn truncate_log(&mut self) -> bool {
+        let result = self.causally_stable_threshold();
+        match result.cloned() {
+            Some(t) => self.state.truncate_log_before(&t),
+            None => false,
+        }
+    }
+}


### PR DESCRIPTION
Basically this moves `Replica` from examples/tree.rs into the core library, renamed as `TreeReplica` and with some improvements.  Most notably the Replica clock is not updated until an operation is actually applied.  This makes it simpler for library users to generate Tree operations correctly.

Also:
* removed pub keyword from module entries in lib.rs
* Revamped and improved doc-comments for all modules
* renamed examples/tree.rs to demo.rs
* modified and improved demos in demo.rs to use new TreeReplica interface

note: I may still experiment with using read and write contexts ala rust-crdt, but for now I think this is a good improvement and is probably simpler for API users.