### PR TITLE
feat: derive missing traits for TreeReplica: Eq, Debug, etc.

### DIFF
--- a/src/treereplica.rs
+++ b/src/treereplica.rs
@@ -9,6 +9,9 @@
 
 extern crate crdts;
 
+use serde::{Deserialize, Serialize};
+use std::cmp::{Eq, PartialEq};
+
 use super::{Clock, LogOpMove, OpMove, State, Tree, TreeId, TreeMeta};
 use crdts::Actor;
 use log::debug;
@@ -25,7 +28,7 @@ use std::collections::HashMap;
 ///
 /// `State` is a lower-level interface to the Tree CRDT and is not tied to any
 /// actor/peer.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TreeReplica<ID: TreeId, TM: TreeMeta, A: Actor> {
     state: State<ID, TM, A>, // Tree state
     time: Clock<A>,          // Lamport Clock for this replica/tree.


### PR DESCRIPTION
Also:
feat: implements fmt::Display() for tree
chore: use HashSet instead of HashMap

**Motivation:**
I ran into an issue using TreeReplica in brb_dt_tree because TreeReplica didn't implement Clone trait amongst others.  So I added those (to match State), and also implemented Display to easily print a tree contents in a semi-formatted fashion, which is helpful for my fork of brb_node_qp2p that is using a tree instead of orswot.